### PR TITLE
feat: Add CRUD modules for Categories, Users, and Tables

### DIFF
--- a/backend/alter_scripts.sql
+++ b/backend/alter_scripts.sql
@@ -1,0 +1,248 @@
+-- -----------------------------------------------------
+-- Archivo de Alteraciones SQL
+-- -----------------------------------------------------
+-- Este archivo contiene los cambios incrementales a la
+-- base de datos, como nuevos procedimientos almacenados
+-- o alteraciones de tablas.
+-- -----------------------------------------------------
+
+-- -----------------------------------------------------
+-- Procedimientos Almacenados para 'categorias_producto'
+-- -----------------------------------------------------
+
+DELIMITER $$
+
+-- Obtener todas las categorías
+CREATE PROCEDURE sp_getAllCategories()
+BEGIN
+    SELECT
+        id,
+        nombre,
+        descripcion
+    FROM
+        categorias_producto
+    ORDER BY
+        nombre ASC;
+END$$
+
+-- Crear una nueva categoría
+CREATE PROCEDURE sp_createCategory(
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT
+)
+BEGIN
+    INSERT INTO categorias_producto (nombre, descripcion)
+    VALUES (p_nombre, p_descripcion);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+-- Leer una categoría por su ID
+CREATE PROCEDURE sp_readOneCategory(
+    IN p_id INT
+)
+BEGIN
+    SELECT
+        id,
+        nombre,
+        descripcion
+    FROM
+        categorias_producto
+    WHERE
+        id = p_id;
+END$$
+
+-- Actualizar una categoría
+CREATE PROCEDURE sp_updateCategory(
+    IN p_id INT,
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT
+)
+BEGIN
+    UPDATE categorias_producto
+    SET
+        nombre = p_nombre,
+        descripcion = p_descripcion
+    WHERE
+        id = p_id;
+END$$
+
+-- Eliminar una categoría
+CREATE PROCEDURE sp_deleteCategory(
+    IN p_id INT
+)
+BEGIN
+    DELETE FROM categorias_producto WHERE id = p_id;
+END$$
+
+DELIMITER ;
+
+-- -----------------------------------------------------
+-- Procedimientos Almacenados para 'mesas'
+-- -----------------------------------------------------
+
+DELIMITER $$
+
+-- Obtener todas las mesas
+CREATE PROCEDURE sp_getAllTables()
+BEGIN
+    SELECT
+        id,
+        numero_mesa,
+        capacidad,
+        estado
+    FROM
+        mesas
+    ORDER BY
+        numero_mesa ASC;
+END$$
+
+-- Crear una nueva mesa
+CREATE PROCEDURE sp_createTable(
+    IN p_numero_mesa VARCHAR(10),
+    IN p_capacidad INT,
+    IN p_estado ENUM('disponible', 'ocupada', 'reservada', 'mantenimiento')
+)
+BEGIN
+    INSERT INTO mesas (numero_mesa, capacidad, estado)
+    VALUES (p_numero_mesa, p_capacidad, p_estado);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+-- Leer una mesa por su ID
+CREATE PROCEDURE sp_readOneTable(
+    IN p_id INT
+)
+BEGIN
+    SELECT
+        id,
+        numero_mesa,
+        capacidad,
+        estado
+    FROM
+        mesas
+    WHERE
+        id = p_id;
+END$$
+
+-- Actualizar una mesa
+CREATE PROCEDURE sp_updateTable(
+    IN p_id INT,
+    IN p_numero_mesa VARCHAR(10),
+    IN p_capacidad INT,
+    IN p_estado ENUM('disponible', 'ocupada', 'reservada', 'mantenimiento')
+)
+BEGIN
+    UPDATE mesas
+    SET
+        numero_mesa = p_numero_mesa,
+        capacidad = p_capacidad,
+        estado = p_estado
+    WHERE
+        id = p_id;
+END$$
+
+-- Eliminar una mesa
+CREATE PROCEDURE sp_deleteTable(
+    IN p_id INT
+)
+BEGIN
+    DELETE FROM mesas WHERE id = p_id;
+END$$
+
+DELIMITER ;
+
+-- -----------------------------------------------------
+-- Procedimientos Almacenados para 'usuarios' y 'roles'
+-- -----------------------------------------------------
+
+DELIMITER $$
+
+-- Obtener todos los roles
+CREATE PROCEDURE sp_getAllRoles()
+BEGIN
+    SELECT id, nombre_rol FROM roles ORDER BY nombre_rol ASC;
+END$$
+
+-- Obtener todos los usuarios
+CREATE PROCEDURE sp_getAllUsers()
+BEGIN
+    SELECT
+        u.id,
+        u.username,
+        u.nombre_completo,
+        u.email,
+        u.id_rol,
+        r.nombre_rol,
+        u.activo
+    FROM
+        usuarios u
+    JOIN
+        roles r ON u.id_rol = r.id
+    ORDER BY
+        u.nombre_completo ASC;
+END$$
+
+-- Crear un nuevo usuario
+CREATE PROCEDURE sp_createUser(
+    IN p_username VARCHAR(50),
+    IN p_nombre_completo VARCHAR(100),
+    IN p_email VARCHAR(100),
+    IN p_password_hash VARCHAR(255),
+    IN p_id_rol INT
+)
+BEGIN
+    INSERT INTO usuarios (username, nombre_completo, email, password_hash, id_rol)
+    VALUES (p_username, p_nombre_completo, p_email, p_password_hash, p_id_rol);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+-- Leer un usuario por su ID
+CREATE PROCEDURE sp_readOneUser(
+    IN p_id INT
+)
+BEGIN
+    SELECT
+        id,
+        username,
+        nombre_completo,
+        email,
+        id_rol,
+        activo
+    FROM
+        usuarios
+    WHERE
+        id = p_id;
+END$$
+
+-- Actualizar un usuario
+CREATE PROCEDURE sp_updateUser(
+    IN p_id INT,
+    IN p_nombre_completo VARCHAR(100),
+    IN p_email VARCHAR(100),
+    IN p_id_rol INT,
+    IN p_activo BOOLEAN,
+    IN p_password_hash VARCHAR(255)
+)
+BEGIN
+    UPDATE usuarios
+    SET
+        nombre_completo = p_nombre_completo,
+        email = p_email,
+        id_rol = p_id_rol,
+        activo = p_activo,
+        -- Solo actualiza la contraseña si se proporciona una nueva
+        password_hash = IF(p_password_hash IS NOT NULL AND p_password_hash != '', p_password_hash, password_hash)
+    WHERE
+        id = p_id;
+END$$
+
+-- Eliminar (desactivar) un usuario
+CREATE PROCEDURE sp_deleteUser(
+    IN p_id INT
+)
+BEGIN
+    -- Se realiza un borrado lógico para no perder la integridad referencial
+    UPDATE usuarios SET activo = 0 WHERE id = p_id;
+END$$
+
+DELIMITER ;

--- a/backend/api/v1/categorias.php
+++ b/backend/api/v1/categorias.php
@@ -1,0 +1,116 @@
+<?php
+// Headers para permitir el acceso desde cualquier origen (CORS) y definir el tipo de contenido.
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+// Incluir archivos de la base de datos y del modelo de categoría.
+include_once __DIR__ . '/../../core/Database.php';
+include_once __DIR__ . '/../../models/Category.php';
+
+$category = new Category();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            // Obtener una sola categoría
+            $category_id = intval($_GET["id"]);
+            $category_data = $category->readOne($category_id);
+            if ($category_data) {
+                http_response_code(200);
+                echo json_encode($category_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(array("message" => "Categoría no encontrada."));
+            }
+        } else {
+            // Obtener todas las categorías
+            handleGetAllCategories($category);
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->nombre)) {
+            $stmt = $category->create($data->nombre, $data->descripcion);
+            if ($stmt) {
+                $new_category = $stmt->fetch(PDO::FETCH_ASSOC);
+                http_response_code(201); // Created
+                echo json_encode(array("message" => "Categoría creada.", "id" => $new_category['id']));
+            } else {
+                http_response_code(503); // Service Unavailable
+                echo json_encode(array("message" => "No se pudo crear la categoría."));
+            }
+        } else {
+            http_response_code(400); // Bad Request
+            echo json_encode(array("message" => "No se pudo crear la categoría. Datos incompletos."));
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->id) && !empty($data->nombre)) {
+            if ($category->update($data->id, $data->nombre, $data->descripcion)) {
+                http_response_code(200);
+                echo json_encode(array("message" => "Categoría actualizada."));
+            } else {
+                http_response_code(503);
+                echo json_encode(array("message" => "No se pudo actualizar la categoría."));
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(array("message" => "No se pudo actualizar la categoría. Datos incompletos."));
+        }
+        break;
+
+    case 'DELETE':
+        if (!empty($_GET["id"])) {
+            $category_id = intval($_GET["id"]);
+            if ($category->delete($category_id)) {
+                http_response_code(200);
+                echo json_encode(array("message" => "Categoría eliminada."));
+            } else {
+                http_response_code(503);
+                echo json_encode(array("message" => "No se pudo eliminar la categoría."));
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(array("message" => "No se proporcionó un ID para eliminar."));
+        }
+        break;
+
+    default:
+        // Método no válido
+        http_response_code(405); // Method Not Allowed
+        echo json_encode(array("message" => "Método no permitido."));
+        break;
+}
+
+function handleGetAllCategories($category) {
+    $stmt = $category->readAll();
+    $num = $stmt->rowCount();
+
+    if ($num > 0) {
+        $categories_arr = array();
+        $categories_arr["records"] = array();
+
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            extract($row);
+            $category_item = array(
+                "id" => $id,
+                "nombre" => $nombre,
+                "descripcion" => html_entity_decode($descripcion)
+            );
+            array_push($categories_arr["records"], $category_item);
+        }
+
+        http_response_code(200);
+        echo json_encode($categories_arr);
+    } else {
+        http_response_code(404);
+        echo json_encode(array("message" => "No se encontraron categorías."));
+    }
+}
+?>

--- a/backend/api/v1/mesas.php
+++ b/backend/api/v1/mesas.php
@@ -1,0 +1,107 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../models/Table.php';
+
+$table = new Table();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            $table_id = intval($_GET["id"]);
+            $table_data = $table->readOne($table_id);
+            if ($table_data) {
+                http_response_code(200);
+                echo json_encode($table_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Mesa no encontrada."]);
+            }
+        } else {
+            handleGetAllTables($table);
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->numero_mesa) && !empty($data->capacidad) && !empty($data->estado)) {
+            $stmt = $table->create($data->numero_mesa, $data->capacidad, $data->estado);
+            if ($stmt) {
+                $new_table = $stmt->fetch(PDO::FETCH_ASSOC);
+                http_response_code(201);
+                echo json_encode(["message" => "Mesa creada.", "id" => $new_table['id']]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear la mesa."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos para crear la mesa."]);
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->id) && !empty($data->numero_mesa) && !empty($data->capacidad) && !empty($data->estado)) {
+            if ($table->update($data->id, $data->numero_mesa, $data->capacidad, $data->estado)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Mesa actualizada."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar la mesa."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos para actualizar la mesa."]);
+        }
+        break;
+
+    case 'DELETE':
+        if (!empty($_GET["id"])) {
+            $table_id = intval($_GET["id"]);
+            if ($table->delete($table_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Mesa eliminada."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar la mesa. Es posible que esté asignada a pedidos o reservas."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "No se proporcionó un ID para eliminar."]);
+        }
+        break;
+
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+
+function handleGetAllTables($table) {
+    $stmt = $table->readAll();
+    $num = $stmt->rowCount();
+    if ($num > 0) {
+        $tables_arr = ["records" => []];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            extract($row);
+            $table_item = [
+                "id" => $id,
+                "numero_mesa" => $numero_mesa,
+                "capacidad" => $capacidad,
+                "estado" => $estado,
+            ];
+            array_push($tables_arr["records"], $table_item);
+        }
+        http_response_code(200);
+        echo json_encode($tables_arr);
+    } else {
+        http_response_code(404);
+        echo json_encode(["message" => "No se encontraron mesas."]);
+    }
+}
+?>

--- a/backend/api/v1/usuarios.php
+++ b/backend/api/v1/usuarios.php
@@ -1,0 +1,140 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../models/User.php';
+
+$user = new User();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        // /usuarios.php?resource=roles
+        if (isset($_GET['resource']) && $_GET['resource'] == 'roles') {
+            handleGetAllRoles($user);
+        }
+        // /usuarios.php?id=1
+        elseif (!empty($_GET["id"])) {
+            $user_id = intval($_GET["id"]);
+            $user_data = $user->readOne($user_id);
+            if ($user_data) {
+                http_response_code(200);
+                echo json_encode($user_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Usuario no encontrado."]);
+            }
+        }
+        // /usuarios.php
+        else {
+            handleGetAllUsers($user);
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->username) && !empty($data->nombre_completo) && !empty($data->password) && !empty($data->id_rol)) {
+            $stmt = $user->create($data->username, $data->nombre_completo, $data->email, $data->password, $data->id_rol);
+            if ($stmt) {
+                $new_user = $stmt->fetch(PDO::FETCH_ASSOC);
+                http_response_code(201);
+                echo json_encode(["message" => "Usuario creado.", "id" => $new_user['id']]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear el usuario."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos para crear el usuario."]);
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->id) && !empty($data->nombre_completo) && isset($data->activo)) {
+            // La contraseña es opcional en la actualización
+            $password = !empty($data->password) ? $data->password : '';
+            if ($user->update($data->id, $data->nombre_completo, $data->email, $data->id_rol, $data->activo, $password)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Usuario actualizado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar el usuario."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos para actualizar el usuario."]);
+        }
+        break;
+
+    case 'DELETE':
+        if (!empty($_GET["id"])) {
+            $user_id = intval($_GET["id"]);
+            if ($user->delete($user_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Usuario desactivado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo desactivar el usuario."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "No se proporcionó un ID para eliminar."]);
+        }
+        break;
+
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+
+function handleGetAllUsers($user) {
+    $stmt = $user->readAll();
+    $num = $stmt->rowCount();
+    if ($num > 0) {
+        $users_arr = ["records" => []];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            extract($row);
+            $user_item = [
+                "id" => $id,
+                "username" => $username,
+                "nombre_completo" => $nombre_completo,
+                "email" => $email,
+                "id_rol" => $id_rol,
+                "nombre_rol" => $nombre_rol,
+                "activo" => $activo,
+            ];
+            array_push($users_arr["records"], $user_item);
+        }
+        http_response_code(200);
+        echo json_encode($users_arr);
+    } else {
+        http_response_code(404);
+        echo json_encode(["message" => "No se encontraron usuarios."]);
+    }
+}
+
+function handleGetAllRoles($user) {
+    $stmt = $user->getAllRoles();
+    $num = $stmt->rowCount();
+    if ($num > 0) {
+        $roles_arr = ["records" => []];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            extract($row);
+            $role_item = [
+                "id" => $id,
+                "nombre_rol" => $nombre_rol,
+            ];
+            array_push($roles_arr["records"], $role_item);
+        }
+        http_response_code(200);
+        echo json_encode($roles_arr);
+    } else {
+        http_response_code(404);
+        echo json_encode(["message" => "No se encontraron roles."]);
+    }
+}
+?>

--- a/backend/models/Category.php
+++ b/backend/models/Category.php
@@ -1,0 +1,96 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class Category {
+    private $conn;
+    private $table_name = "categorias_producto";
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    /**
+     * Lee todas las categorías.
+     * @return PDOStatement
+     */
+    public function readAll() {
+        $query = "CALL sp_getAllCategories()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Crea una nueva categoría.
+     * @return PDOStatement|false
+     */
+    public function create($nombre, $descripcion) {
+        $query = "CALL sp_createCategory(:nombre, :descripcion)";
+        $stmt = $this->conn->prepare($query);
+
+        // Limpiar datos
+        $nombre = htmlspecialchars(strip_tags($nombre));
+        $descripcion = htmlspecialchars(strip_tags($descripcion));
+
+        // Enlazar parámetros
+        $stmt->bindParam(':nombre', $nombre);
+        $stmt->bindParam(':descripcion', $descripcion);
+
+        if ($stmt->execute()) {
+            return $stmt;
+        }
+        return false;
+    }
+
+    /**
+     * Lee una sola categoría por su ID.
+     * @return array|false
+     */
+    public function readOne($id) {
+        $query = "CALL sp_readOneCategory(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Actualiza una categoría existente.
+     * @return bool
+     */
+    public function update($id, $nombre, $descripcion) {
+        $query = "CALL sp_updateCategory(:id, :nombre, :descripcion)";
+        $stmt = $this->conn->prepare($query);
+
+        // Limpiar datos
+        $id = htmlspecialchars(strip_tags($id));
+        $nombre = htmlspecialchars(strip_tags($nombre));
+        $descripcion = htmlspecialchars(strip_tags($descripcion));
+
+        // Enlazar parámetros
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':nombre', $nombre);
+        $stmt->bindParam(':descripcion', $descripcion);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Elimina una categoría.
+     * @return bool
+     */
+    public function delete($id) {
+        $query = "CALL sp_deleteCategory(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+        return false;
+    }
+}
+?>

--- a/backend/models/Table.php
+++ b/backend/models/Table.php
@@ -1,0 +1,69 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class Table {
+    private $conn;
+    private $table_name = "mesas";
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    public function readAll() {
+        $query = "CALL sp_getAllTables()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    public function readOne($id) {
+        $query = "CALL sp_readOneTable(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($numero_mesa, $capacidad, $estado) {
+        $query = "CALL sp_createTable(:numero_mesa, :capacidad, :estado)";
+        $stmt = $this->conn->prepare($query);
+
+        $numero_mesa = htmlspecialchars(strip_tags($numero_mesa));
+        $capacidad = htmlspecialchars(strip_tags($capacidad));
+        $estado = htmlspecialchars(strip_tags($estado));
+
+        $stmt->bindParam(':numero_mesa', $numero_mesa);
+        $stmt->bindParam(':capacidad', $capacidad);
+        $stmt->bindParam(':estado', $estado);
+
+        if ($stmt->execute()) {
+            return $stmt;
+        }
+        return false;
+    }
+
+    public function update($id, $numero_mesa, $capacidad, $estado) {
+        $query = "CALL sp_updateTable(:id, :numero_mesa, :capacidad, :estado)";
+        $stmt = $this->conn->prepare($query);
+
+        $id = htmlspecialchars(strip_tags($id));
+        $numero_mesa = htmlspecialchars(strip_tags($numero_mesa));
+        $capacidad = htmlspecialchars(strip_tags($capacidad));
+        $estado = htmlspecialchars(strip_tags($estado));
+
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':numero_mesa', $numero_mesa);
+        $stmt->bindParam(':capacidad', $capacidad);
+        $stmt->bindParam(':estado', $estado);
+
+        return $stmt->execute();
+    }
+
+    public function delete($id) {
+        $query = "CALL sp_deleteTable(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        return $stmt->execute();
+    }
+}
+?>

--- a/backend/models/User.php
+++ b/backend/models/User.php
@@ -7,33 +7,28 @@ class User {
 
     // Propiedades del objeto Usuario
     public $id;
+    public $username;
     public $nombre_completo;
     public $email;
     public $password_hash;
     public $id_rol;
+    public $nombre_rol;
     public $activo;
 
     public function __construct() {
         $this->conn = Database::getInstance();
     }
 
-    /**
-     * Busca un usuario por su nombre de usuario.
-     *
-     * @param string $username El nombre de usuario a buscar.
-     * @return bool True si el usuario existe, False si no.
-     */
+    // --- Métodos de Autenticación ---
+
     public function findByUsername($username) {
         $query = "CALL sp_getUserByUsername(:username)";
-
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':username', $username);
         $stmt->execute();
 
         if ($stmt->rowCount() > 0) {
             $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
-            // Asignar valores a las propiedades del objeto
             $this->id = $row['id'];
             $this->username = $row['username'];
             $this->nombre_completo = $row['nombre_completo'];
@@ -41,21 +36,95 @@ class User {
             $this->password_hash = $row['password_hash'];
             $this->id_rol = $row['id_rol'];
             $this->nombre_rol = $row['nombre_rol'];
-
             return true;
         }
-
         return false;
     }
 
-    /**
-     * Verifica la contraseña del usuario.
-     *
-     * @param string $password La contraseña en texto plano.
-     * @return bool True si la contraseña es correcta, False si no.
-     */
     public function verifyPassword($password) {
         return password_verify($password, $this->password_hash);
+    }
+
+    // --- Métodos CRUD ---
+
+    public function readAll() {
+        $query = "CALL sp_getAllUsers()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    public function readOne($id) {
+        $query = "CALL sp_readOneUser(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($username, $nombre_completo, $email, $password, $id_rol) {
+        $password_hash = password_hash($password, PASSWORD_BCRYPT);
+        $query = "CALL sp_createUser(:username, :nombre_completo, :email, :password_hash, :id_rol)";
+        $stmt = $this->conn->prepare($query);
+
+        // Limpieza de datos
+        $username = htmlspecialchars(strip_tags($username));
+        $nombre_completo = htmlspecialchars(strip_tags($nombre_completo));
+        $email = htmlspecialchars(strip_tags($email));
+        $id_rol = htmlspecialchars(strip_tags($id_rol));
+
+        $stmt->bindParam(':username', $username);
+        $stmt->bindParam(':nombre_completo', $nombre_completo);
+        $stmt->bindParam(':email', $email);
+        $stmt->bindParam(':password_hash', $password_hash);
+        $stmt->bindParam(':id_rol', $id_rol);
+
+        if ($stmt->execute()) {
+            return $stmt;
+        }
+        return false;
+    }
+
+    public function update($id, $nombre_completo, $email, $id_rol, $activo, $password) {
+        $password_hash = null;
+        if (!empty($password)) {
+            $password_hash = password_hash($password, PASSWORD_BCRYPT);
+        }
+
+        $query = "CALL sp_updateUser(:id, :nombre_completo, :email, :id_rol, :activo, :password_hash)";
+        $stmt = $this->conn->prepare($query);
+
+        // Limpieza de datos
+        $id = htmlspecialchars(strip_tags($id));
+        $nombre_completo = htmlspecialchars(strip_tags($nombre_completo));
+        $email = htmlspecialchars(strip_tags($email));
+        $id_rol = htmlspecialchars(strip_tags($id_rol));
+        $activo = htmlspecialchars(strip_tags($activo));
+
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':nombre_completo', $nombre_completo);
+        $stmt->bindParam(':email', $email);
+        $stmt->bindParam(':id_rol', $id_rol);
+        $stmt->bindParam(':activo', $activo, PDO::PARAM_BOOL);
+        $stmt->bindParam(':password_hash', $password_hash);
+
+        return $stmt->execute();
+    }
+
+    public function delete($id) {
+        $query = "CALL sp_deleteUser(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        return $stmt->execute();
+    }
+
+    // --- Métodos Auxiliares ---
+
+    public function getAllRoles() {
+        $query = "CALL sp_getAllRoles()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
     }
 }
 ?>

--- a/frontend_web/categoria_delete_handler.php
+++ b/frontend_web/categoria_delete_handler.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    $category_id = $_GET['id'];
+    $api_url = "http://localhost/restaurante_system/backend/api/v1/categorias.php?id=$category_id";
+
+    // Configurar cURL para una solicitud DELETE
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    if ($http_code === 200) {
+        $message = urlencode($response_data['message']);
+        header("Location: categorias.php?success=$message");
+    } else {
+        $error = isset($response_data['message']) ? urlencode($response_data['message']) : 'Error al eliminar la categoría.';
+        header("Location: categorias.php?error=$error");
+    }
+    exit();
+} else {
+    // Si no se proporciona ID, redirigir
+    header('Location: categorias.php?error=' . urlencode('No se proporcionó un ID para eliminar.'));
+    exit();
+}
+?>

--- a/frontend_web/categoria_form.php
+++ b/frontend_web/categoria_form.php
@@ -1,0 +1,69 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+include_once 'templates/header.php';
+
+$category_data = [
+    'id' => '',
+    'nombre' => '',
+    'descripcion' => ''
+];
+$page_title = 'Crear Categoría';
+$action = 'categoria_handler.php';
+
+// Si se proporciona un ID, estamos editando
+if (isset($_GET['id'])) {
+    $category_id = $_GET['id'];
+    $api_url = "http://localhost/restaurante_system/backend/api/v1/categorias.php?id=$category_id";
+
+    $response = file_get_contents($api_url);
+    if ($response) {
+        $category_data = json_decode($response, true);
+    }
+
+    $page_title = 'Editar Categoría';
+}
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+            </div>
+
+            <div class="form-container">
+                <form action="<?php echo $action; ?>" method="POST">
+                    <!-- Campo oculto para el ID en caso de edición -->
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($category_data['id']); ?>">
+
+                    <div class="form-group">
+                        <label for="nombre">Nombre de la Categoría</label>
+                        <input type="text" id="nombre" name="nombre" value="<?php echo htmlspecialchars($category_data['nombre']); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="descripcion">Descripción</label>
+                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($category_data['descripcion']); ?></textarea>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn">Guardar Cambios</button>
+                        <a href="categorias.php" class="btn btn-secondary">Cancelar</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>
+
+<?php
+include_once 'templates/footer.php';
+?>

--- a/frontend_web/categoria_handler.php
+++ b/frontend_web/categoria_handler.php
@@ -1,0 +1,53 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/categorias.php';
+    $data = [
+        'nombre' => $_POST['nombre'],
+        'descripcion' => $_POST['descripcion']
+    ];
+    $http_method = 'POST'; // Por defecto, para crear
+
+    // Si hay un ID, es una actualización (PUT)
+    if (!empty($_POST['id'])) {
+        $data['id'] = $_POST['id'];
+        $http_method = 'PUT';
+    }
+
+    // Configurar cURL
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $http_method);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    // Redirigir según el resultado
+    if ($http_code === 201 || $http_code === 200) {
+        $message = urlencode($response_data['message']);
+        header("Location: categorias.php?success=$message");
+    } else {
+        $error = isset($response_data['message']) ? urlencode($response_data['message']) : 'Ocurrió un error inesperado.';
+        header("Location: categorias.php?error=$error");
+    }
+    exit();
+} else {
+    // Si no es POST, redirigir
+    header('Location: categorias.php');
+    exit();
+}
+?>

--- a/frontend_web/categorias.php
+++ b/frontend_web/categorias.php
@@ -1,0 +1,94 @@
+<?php
+session_start();
+
+// Proteger la página
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+$page_title = 'Gestión de Categorías';
+include_once 'templates/header.php';
+
+// Función para obtener categorías desde la API
+function getCategories() {
+    // La URL de la API debe ser accesible desde el servidor donde se ejecuta este script.
+    // Usar localhost puede no funcionar si el entorno de ejecución está en un contenedor Docker o similar.
+    // Asegúrate de que la URL es la correcta para tu entorno.
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/categorias.php';
+
+    // Usar cURL para más flexibilidad
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $response = curl_exec($ch);
+    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    // Solo decodificar si la respuesta es exitosa
+    if ($httpcode == 200) {
+        return json_decode($response, true);
+    }
+    return ['records' => []]; // Devolver un array vacío si hay un error
+}
+
+$categories_data = getCategories();
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1>Catálogo de Categorías</h1>
+                <a href="categoria_form.php" class="btn">Crear Categoría Nueva</a>
+            </div>
+
+            <?php
+            if (isset($_GET['success'])) {
+                echo '<p class="success-message">' . htmlspecialchars($_GET['success']) . '</p>';
+            }
+            if (isset($_GET['error'])) {
+                echo '<p class="error-message">' . htmlspecialchars($_GET['error']) . '</p>';
+            }
+            ?>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Nombre</th>
+                            <th>Descripción</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (isset($categories_data['records']) && !empty($categories_data['records'])): ?>
+                            <?php foreach ($categories_data['records'] as $category): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($category['id']); ?></td>
+                                    <td><?php echo htmlspecialchars($category['nombre']); ?></td>
+                                    <td><?php echo htmlspecialchars($category['descripcion']); ?></td>
+                                    <td class="actions-cell">
+                                        <a href="categoria_form.php?id=<?php echo $category['id']; ?>" class="btn-edit">Editar</a>
+                                        <a href="categoria_delete_handler.php?id=<?php echo $category['id']; ?>" class="btn-delete" onclick="return confirm('¿Estás seguro de que quieres eliminar esta categoría?');">Eliminar</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr>
+                                <td colspan="4">No se encontraron categorías. Puede que no haya ninguna registrada.</td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+</div>
+
+<?php
+include_once 'templates/footer.php';
+?>

--- a/frontend_web/mesa_delete_handler.php
+++ b/frontend_web/mesa_delete_handler.php
@@ -1,0 +1,35 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    $table_id = intval($_GET['id']);
+    $api_url = "http://localhost/restaurante_system/backend/api/v1/mesas.php?id=$table_id";
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    if ($http_code === 200) {
+        $message = urlencode($response_data['message']);
+        header("Location: mesas.php?success=$message");
+    } else {
+        $error = isset($response_data['message']) ? urlencode($response_data['message']) : 'Error al eliminar la mesa.';
+        header("Location: mesas.php?error=$error");
+    }
+    exit();
+} else {
+    header('Location: mesas.php?error=' . urlencode('No se proporcionó un ID para eliminar.'));
+    exit();
+}
+?>

--- a/frontend_web/mesa_form.php
+++ b/frontend_web/mesa_form.php
@@ -1,0 +1,80 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+include_once 'templates/header.php';
+
+$table_data = [
+    'id' => '',
+    'numero_mesa' => '',
+    'capacidad' => '',
+    'estado' => 'disponible' // Valor por defecto
+];
+$page_title = 'Crear Mesa';
+$is_editing = false;
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $table_id = $_GET['id'];
+    $api_url = "http://localhost/restaurante_system/backend/api/v1/mesas.php?id=$table_id";
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $table_data = json_decode($response, true);
+    }
+    $page_title = 'Editar Mesa';
+}
+
+$estados = ['disponible', 'ocupada', 'reservada', 'mantenimiento'];
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+            </div>
+
+            <div class="form-container">
+                <form action="mesa_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($table_data['id']); ?>">
+
+                    <div class="form-group">
+                        <label for="numero_mesa">Número de Mesa</label>
+                        <input type="text" id="numero_mesa" name="numero_mesa" value="<?php echo htmlspecialchars($table_data['numero_mesa']); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="capacidad">Capacidad</label>
+                        <input type="number" id="capacidad" name="capacidad" value="<?php echo htmlspecialchars($table_data['capacidad']); ?>" required min="1">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="estado">Estado</label>
+                        <select id="estado" name="estado" required>
+                            <?php foreach ($estados as $estado): ?>
+                                <option value="<?php echo $estado; ?>" <?php if ($estado == $table_data['estado']) echo 'selected'; ?>>
+                                    <?php echo ucfirst($estado); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn">Guardar Cambios</button>
+                        <a href="mesas.php" class="btn btn-secondary">Cancelar</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>
+
+<?php
+include_once 'templates/footer.php';
+?>

--- a/frontend_web/mesa_handler.php
+++ b/frontend_web/mesa_handler.php
@@ -1,0 +1,50 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/mesas.php';
+    $data = [
+        'numero_mesa' => $_POST['numero_mesa'],
+        'capacidad' => $_POST['capacidad'],
+        'estado' => $_POST['estado']
+    ];
+    $http_method = 'POST';
+
+    if (!empty($_POST['id'])) {
+        $data['id'] = $_POST['id'];
+        $http_method = 'PUT';
+    }
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $http_method);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    if ($http_code === 201 || $http_code === 200) {
+        $message = urlencode($response_data['message']);
+        header("Location: mesas.php?success=$message");
+    } else {
+        $error = isset($response_data['message']) ? urlencode($response_data['message']) : 'Ocurrió un error inesperado.';
+        header("Location: mesa_form.php?id=" . $_POST['id'] . "&error=$error");
+    }
+    exit();
+} else {
+    header('Location: mesas.php');
+    exit();
+}
+?>

--- a/frontend_web/mesas.php
+++ b/frontend_web/mesas.php
@@ -1,0 +1,101 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+$page_title = 'Gestión de Mesas';
+include_once 'templates/header.php';
+
+function getTables() {
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/mesas.php';
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        return json_decode($response, true);
+    }
+    return ['records' => []];
+}
+
+$tables_data = getTables();
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1>Gestión de Mesas del Restaurante</h1>
+                <a href="mesa_form.php" class="btn">Crear Mesa Nueva</a>
+            </div>
+
+            <?php
+            if (isset($_GET['success'])) {
+                echo '<p class="success-message">' . htmlspecialchars($_GET['success']) . '</p>';
+            }
+            if (isset($_GET['error'])) {
+                echo '<p class="error-message">' . htmlspecialchars($_GET['error']) . '</p>';
+            }
+            ?>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Número de Mesa</th>
+                            <th>Capacidad</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (isset($tables_data['records']) && !empty($tables_data['records'])): ?>
+                            <?php foreach ($tables_data['records'] as $table): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($table['id']); ?></td>
+                                    <td><?php echo htmlspecialchars($table['numero_mesa']); ?></td>
+                                    <td><?php echo htmlspecialchars($table['capacidad']); ?> personas</td>
+                                    <td>
+                                        <span class="status status-<?php echo htmlspecialchars($table['estado']); ?>">
+                                            <?php echo htmlspecialchars(ucfirst($table['estado'])); ?>
+                                        </span>
+                                    </td>
+                                    <td class="actions-cell">
+                                        <a href="mesa_form.php?id=<?php echo $table['id']; ?>" class="btn-edit">Editar</a>
+                                        <a href="mesa_delete_handler.php?id=<?php echo $table['id']; ?>" class="btn-delete" onclick="return confirm('¿Estás seguro de que quieres eliminar esta mesa? Esta acción no se puede deshacer.');">Eliminar</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr>
+                                <td colspan="5">No se encontraron mesas.</td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+</div>
+
+<style>
+.status {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: bold;
+    color: #fff;
+    text-transform: capitalize;
+}
+.status-disponible { background-color: #28a745; } /* Verde */
+.status-ocupada { background-color: #dc3545; } /* Rojo */
+.status-reservada { background-color: #ffc107; color: #000; } /* Amarillo */
+.status-mantenimiento { background-color: #6c757d; } /* Gris */
+</style>
+
+<?php
+include_once 'templates/footer.php';
+?>

--- a/frontend_web/templates/sidebar.php
+++ b/frontend_web/templates/sidebar.php
@@ -3,6 +3,7 @@
     <ul>
         <li><a href="dashboard.php">Inicio</a></li>
         <li><a href="productos.php">Productos</a></li>
+        <li><a href="categorias.php">Categorías</a></li>
         <li><a href="mesas.php">Mesas</a></li>
         <li><a href="pedidos.php">Pedidos</a></li>
         <li><a href="reservas.php">Reservas</a></li>

--- a/frontend_web/usuario_delete_handler.php
+++ b/frontend_web/usuario_delete_handler.php
@@ -1,0 +1,42 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['user_rol'] !== 'Administrador') {
+    header('Location: dashboard.php?error=Acceso+no+autorizado');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    $user_id = intval($_GET['id']);
+
+    // Salvaguarda para no eliminar al administrador principal
+    if ($user_id === 1) {
+        header('Location: usuarios.php?error=' . urlencode('No se puede desactivar al administrador principal.'));
+        exit();
+    }
+
+    $api_url = "http://localhost/restaurante_system/backend/api/v1/usuarios.php?id=$user_id";
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    if ($http_code === 200) {
+        $message = urlencode($response_data['message']);
+        header("Location: usuarios.php?success=$message");
+    } else {
+        $error = isset($response_data['message']) ? urlencode($response_data['message']) : 'Error al desactivar el usuario.';
+        header("Location: usuarios.php?error=$error");
+    }
+    exit();
+} else {
+    header('Location: usuarios.php?error=' . urlencode('No se proporcionó un ID.'));
+    exit();
+}
+?>

--- a/frontend_web/usuario_form.php
+++ b/frontend_web/usuario_form.php
@@ -1,0 +1,122 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['user_rol'] !== 'Administrador') {
+    header('Location: dashboard.php?error=Acceso+no+autorizado');
+    exit();
+}
+
+include_once 'templates/header.php';
+
+// --- Estado inicial y variables ---
+$user_data = [
+    'id' => '',
+    'username' => '',
+    'nombre_completo' => '',
+    'email' => '',
+    'id_rol' => '',
+    'activo' => 1 // Por defecto, un nuevo usuario está activo
+];
+$page_title = 'Crear Usuario';
+$is_editing = false;
+
+// --- Funciones de API ---
+function getRoles() {
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/usuarios.php?resource=roles';
+    $response = file_get_contents($api_url);
+    return $response ? json_decode($response, true)['records'] : [];
+}
+
+function getUserById($id) {
+    $api_url = "http://localhost/restaurante_system/backend/api/v1/usuarios.php?id=$id";
+    $response = file_get_contents($api_url);
+    return $response ? json_decode($response, true) : null;
+}
+
+// --- Lógica de la página ---
+$roles = getRoles();
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $user_id = $_GET['id'];
+    $fetched_user = getUserById($user_id);
+    if ($fetched_user) {
+        $user_data = $fetched_user;
+    }
+    $page_title = 'Editar Usuario';
+}
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+            </div>
+
+            <div class="form-container">
+                <form action="usuario_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($user_data['id']); ?>">
+
+                    <div class="form-group">
+                        <label for="username">Username</label>
+                        <input type="text" id="username" name="username" value="<?php echo htmlspecialchars($user_data['username']); ?>" <?php if ($is_editing) echo 'readonly'; ?> required>
+                        <?php if ($is_editing): ?>
+                            <small>El username no se puede cambiar.</small>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="nombre_completo">Nombre Completo</label>
+                        <input type="text" id="nombre_completo" name="nombre_completo" value="<?php echo htmlspecialchars($user_data['nombre_completo']); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="email">Email</label>
+                        <input type="email" id="email" name="email" value="<?php echo htmlspecialchars($user_data['email']); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="password">Contraseña</label>
+                        <input type="password" id="password" name="password" <?php if (!$is_editing) echo 'required'; ?>>
+                        <?php if ($is_editing): ?>
+                            <small>Dejar en blanco para no cambiar la contraseña.</small>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="id_rol">Rol</label>
+                        <select id="id_rol" name="id_rol" required>
+                            <?php foreach ($roles as $rol): ?>
+                                <option value="<?php echo $rol['id']; ?>" <?php if ($rol['id'] == $user_data['id_rol']) echo 'selected'; ?>>
+                                    <?php echo htmlspecialchars($rol['nombre_rol']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <?php if ($is_editing): ?>
+                    <div class="form-group">
+                        <label for="activo">Estado</label>
+                        <select id="activo" name="activo" required>
+                            <option value="1" <?php if ($user_data['activo'] == 1) echo 'selected'; ?>>Activo</option>
+                            <option value="0" <?php if ($user_data['activo'] == 0) echo 'selected'; ?>>Inactivo</option>
+                        </select>
+                    </div>
+                    <?php endif; ?>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn">Guardar Cambios</button>
+                        <a href="usuarios.php" class="btn btn-secondary">Cancelar</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>
+
+<?php
+include_once 'templates/footer.php';
+?>

--- a/frontend_web/usuario_handler.php
+++ b/frontend_web/usuario_handler.php
@@ -1,0 +1,61 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['user_rol'] !== 'Administrador') {
+    header('Location: dashboard.php?error=Acceso+no+autorizado');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/usuarios.php';
+    $data = [
+        'nombre_completo' => $_POST['nombre_completo'],
+        'email' => $_POST['email'],
+        'id_rol' => $_POST['id_rol']
+    ];
+    $http_method = 'POST'; // Por defecto para crear
+
+    // Si hay un ID, es una actualización (PUT)
+    if (!empty($_POST['id'])) {
+        $data['id'] = $_POST['id'];
+        $data['activo'] = $_POST['activo']; // El estado solo se envía en la actualización
+        $http_method = 'PUT';
+    } else {
+        // El username y la contraseña son obligatorios solo al crear
+        $data['username'] = $_POST['username'];
+        $data['password'] = $_POST['password'];
+    }
+
+    // La contraseña es opcional al actualizar
+    if (!empty($_POST['password'])) {
+        $data['password'] = $_POST['password'];
+    }
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $http_method);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    if ($http_code === 201 || $http_code === 200) {
+        $message = urlencode($response_data['message']);
+        header("Location: usuarios.php?success=$message");
+    } else {
+        $error = isset($response_data['message']) ? urlencode($response_data['message']) : 'Ocurrió un error inesperado.';
+        header("Location: usuario_form.php?id=" . $_POST['id'] . "&error=$error");
+    }
+    exit();
+} else {
+    header('Location: usuarios.php');
+    exit();
+}
+?>

--- a/frontend_web/usuarios.php
+++ b/frontend_web/usuarios.php
@@ -1,0 +1,110 @@
+<?php
+session_start();
+
+// Proteger la página y asegurar que solo el administrador pueda acceder
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['user_rol'] !== 'Administrador') {
+    header('Location: dashboard.php?error=Acceso+no+autorizado');
+    exit();
+}
+
+$page_title = 'Gestión de Usuarios';
+include_once 'templates/header.php';
+
+function getUsers() {
+    $api_url = 'http://localhost/restaurante_system/backend/api/v1/usuarios.php';
+    $response = file_get_contents($api_url);
+    if ($response) {
+        return json_decode($response, true);
+    }
+    return ['records' => []];
+}
+
+$users_data = getUsers();
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1>Gestión de Usuarios del Sistema</h1>
+                <a href="usuario_form.php" class="btn">Crear Usuario Nuevo</a>
+            </div>
+
+            <?php
+            if (isset($_GET['success'])) {
+                echo '<p class="success-message">' . htmlspecialchars($_GET['success']) . '</p>';
+            }
+            if (isset($_GET['error'])) {
+                echo '<p class="error-message">' . htmlspecialchars($_GET['error']) . '</p>';
+            }
+            ?>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Username</th>
+                            <th>Nombre Completo</th>
+                            <th>Email</th>
+                            <th>Rol</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (isset($users_data['records']) && !empty($users_data['records'])): ?>
+                            <?php foreach ($users_data['records'] as $user): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($user['id']); ?></td>
+                                    <td><?php echo htmlspecialchars($user['username']); ?></td>
+                                    <td><?php echo htmlspecialchars($user['nombre_completo']); ?></td>
+                                    <td><?php echo htmlspecialchars($user['email']); ?></td>
+                                    <td><?php echo htmlspecialchars($user['nombre_rol']); ?></td>
+                                    <td>
+                                        <span class="status <?php echo $user['activo'] ? 'status-active' : 'status-inactive'; ?>">
+                                            <?php echo $user['activo'] ? 'Activo' : 'Inactivo'; ?>
+                                        </span>
+                                    </td>
+                                    <td class="actions-cell">
+                                        <a href="usuario_form.php?id=<?php echo $user['id']; ?>" class="btn-edit">Editar</a>
+                                        <!-- El botón de eliminar solo se muestra si el usuario no es el admin principal (ID 1) -->
+                                        <?php if ($user['id'] != 1): ?>
+                                            <a href="usuario_delete_handler.php?id=<?php echo $user['id']; ?>" class="btn-delete" onclick="return confirm('¿Estás seguro de que quieres desactivar a este usuario?');">Desactivar</a>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr>
+                                <td colspan="7">No se encontraron usuarios.</td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+</div>
+
+<style>
+.status {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: bold;
+    color: #fff;
+}
+.status-active {
+    background-color: #28a745; /* Verde */
+}
+.status-inactive {
+    background-color: #6c757d; /* Gris */
+}
+</style>
+
+<?php
+include_once 'templates/footer.php';
+?>


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) maintenance modules for three core entities in the web application: Product Categories, Users, and Tables.

The implementation follows a consistent, full-stack pattern for each module:
- **Database**: New stored procedures for all CRUD operations have been added to a dedicated `backend/alter_scripts.sql` file as requested.
- **Backend**: New models and API endpoints were created to handle the business logic and provide RESTful services for each entity.
- **Frontend**: New PHP pages were created to provide a user interface for listing, creating, editing, and deleting items in each module. This includes forms, handlers, and list views.
- **Navigation**: The sidebar has been updated to include links to the new modules.

This change significantly enhances the administrative capabilities of the web application, allowing for easy management of key data.