### PR TITLE
fix: Refine forms with dynamic and filtered data

### DIFF
--- a/backend/alter_scripts.sql
+++ b/backend/alter_scripts.sql
@@ -40,6 +40,25 @@ BEGIN
     DELETE FROM categorias_producto WHERE id = p_id;
 END$$
 
+DROP PROCEDURE IF EXISTS sp_getUsersByRole$$
+CREATE PROCEDURE sp_getUsersByRole(IN p_role_name VARCHAR(50))
+BEGIN
+    SELECT
+        u.id,
+        u.username,
+        u.nombre_completo,
+        u.email,
+        u.id_rol,
+        r.nombre_rol,
+        u.activo
+    FROM
+        usuarios u
+    JOIN
+        roles r ON u.id_rol = r.id
+    WHERE
+        r.nombre_rol = p_role_name AND u.activo = 1;
+END$$
+
 DELIMITER ;
 
 -- -----------------------------------------------------

--- a/backend/api/v1/usuarios.php
+++ b/backend/api/v1/usuarios.php
@@ -9,10 +9,39 @@ include_once __DIR__ . '/../../models/User.php';
 $user = new User();
 $request_method = $_SERVER["REQUEST_METHOD"];
 
+function handleGetUsersByRole($user, $roleName) {
+    $stmt = $user->getUsersByRole($roleName);
+    $num = $stmt->rowCount();
+    if ($num > 0) {
+        $users_arr = ["records" => []];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $user_item = [
+                "id" => $row['id'],
+                "username" => $row['username'],
+                "nombre_completo" => $row['nombre_completo'],
+                "email" => $row['email'],
+                "id_rol" => $row['id_rol'],
+                "nombre_rol" => $row['nombre_rol'],
+                "activo" => $row['activo'],
+            ];
+            array_push($users_arr["records"], $user_item);
+        }
+        http_response_code(200);
+        echo json_encode($users_arr);
+    } else {
+        http_response_code(200);
+        echo json_encode(["records" => []]);
+    }
+}
+
 switch ($request_method) {
     case 'GET':
+        // /usuarios.php?rol=Mozo
+        if (isset($_GET['rol'])) {
+            handleGetUsersByRole($user, $_GET['rol']);
+        }
         // /usuarios.php?resource=roles
-        if (isset($_GET['resource']) && $_GET['resource'] == 'roles') {
+        elseif (isset($_GET['resource']) && $_GET['resource'] == 'roles') {
             handleGetAllRoles($user);
         }
         // /usuarios.php?id=1

--- a/backend/models/User.php
+++ b/backend/models/User.php
@@ -126,5 +126,13 @@ class User {
         $stmt->execute();
         return $stmt;
     }
+
+    public function getUsersByRole($roleName) {
+        $query = "CALL sp_getUsersByRole(:role_name)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':role_name', $roleName);
+        $stmt->execute();
+        return $stmt;
+    }
 }
 ?>

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -21,7 +21,7 @@ function getAPIdata($endpoint) {
 }
 
 $mesas = getAPIdata('mesas.php');
-$mozos = getAPIdata('usuarios.php'); // Asumimos que todos los usuarios pueden ser mozos por ahora
+$mozos = getAPIdata('usuarios.php?rol=Mozo'); // Obtener solo usuarios con el rol de Mozo
 $categorias = getAPIdata('categorias.php');
 $productos = getAPIdata('productos.php');
 

--- a/frontend_web/producto_form.php
+++ b/frontend_web/producto_form.php
@@ -13,22 +13,25 @@ $product_data = null;
 $page_title = 'Crear Nuevo Producto';
 $form_action = 'create';
 
+function getAPIdata($url) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($response, true);
+}
+
 if ($product_id) {
     // Si es una edición, obtener los datos del producto desde la API
     $api_url = "http://localhost/restaurante_system/backend/api/v1/productos.php?id=" . $product_id;
-    $response = file_get_contents($api_url);
-    $product_data = json_decode($response, true);
+    $product_data = getAPIdata($api_url);
     $page_title = 'Editar Producto';
     $form_action = 'update';
 }
 
-// Placeholder para categorías. Esto debería venir de una llamada a la API en el futuro.
-$categories = [
-    ['id' => 1, 'nombre' => 'Bebidas'],
-    ['id' => 2, 'nombre' => 'Entradas'],
-    ['id' => 3, 'nombre' => 'Plato Fuerte'],
-    ['id' => 4, 'nombre' => 'Postres']
-];
+// Cargar categorías dinámicamente desde la API
+$categories_data = getAPIdata("http://localhost/restaurante_system/backend/api/v1/categorias.php");
+$categories = $categories_data['records'] ?? [];
 
 ?>
 


### PR DESCRIPTION
This commit addresses two follow-up requests to improve data accuracy in forms:

1.  **Filter Waiters in Order Form:**
    - A new stored procedure `sp_getUsersByRole` was created to fetch users by their role.
    - The backend API for users was updated to support filtering by role (e.g., `?rol=Mozo`).
    - The "Create Order" form (`pedido_form.php`) is now updated to call this filtered endpoint, ensuring only users with the 'Mozo' role appear in the selection dropdown.

2.  **Dynamic Categories in Product Form:**
    - The "Create/Edit Product" form (`producto_form.php`) has been updated to dynamically fetch the list of categories from the `categorias` API endpoint.
    - This replaces the previous hardcoded placeholder list, ensuring that the product form always reflects the categories currently managed in the system.