### PR TITLE
fix: Prevent order detail error with LEFT JOIN

### DIFF
--- a/backend/alter_scripts.sql
+++ b/backend/alter_scripts.sql
@@ -154,8 +154,8 @@ CREATE PROCEDURE sp_getAllOrders()
 BEGIN
     SELECT p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion
     FROM pedidos p
-    JOIN mesas m ON p.id_mesa = m.id
-    JOIN usuarios u ON p.id_usuario_mozo = u.id
+    LEFT JOIN mesas m ON p.id_mesa = m.id
+    LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id
     ORDER BY p.fecha_creacion DESC;
 END$$
 
@@ -164,8 +164,8 @@ CREATE PROCEDURE sp_getOrderDetail(IN p_id_pedido INT)
 BEGIN
     SELECT p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion, p.fecha_actualizacion
     FROM pedidos p
-    JOIN mesas m ON p.id_mesa = m.id
-    JOIN usuarios u ON p.id_usuario_mozo = u.id
+    LEFT JOIN mesas m ON p.id_mesa = m.id
+    LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id
     WHERE p.id = p_id_pedido;
 END$$
 

--- a/frontend_web/pedido_detalle.php
+++ b/frontend_web/pedido_detalle.php
@@ -48,8 +48,8 @@ $order = getOrderDetails($order_id);
                 <div class="order-details-container">
                     <div class="order-header">
                         <h3>Información General</h3>
-                        <p><strong>Mesa:</strong> <?php echo htmlspecialchars($order['numero_mesa']); ?></p>
-                        <p><strong>Mozo:</strong> <?php echo htmlspecialchars($order['nombre_mozo']); ?></p>
+                        <p><strong>Mesa:</strong> <?php echo htmlspecialchars($order['numero_mesa'] ?? 'N/A'); ?></p>
+                        <p><strong>Mozo:</strong> <?php echo htmlspecialchars($order['nombre_mozo'] ?? 'N/A'); ?></p>
                         <p><strong>Estado:</strong>
                             <span class="status status-<?php echo htmlspecialchars($order['estado']); ?>">
                                 <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $order['estado']))); ?>

--- a/frontend_web/pedidos.php
+++ b/frontend_web/pedidos.php
@@ -59,8 +59,8 @@ $orders_data = getOrders();
                             <?php foreach ($orders_data['records'] as $order): ?>
                                 <tr>
                                     <td>#<?php echo htmlspecialchars($order['id']); ?></td>
-                                    <td><?php echo htmlspecialchars($order['numero_mesa']); ?></td>
-                                    <td><?php echo htmlspecialchars($order['nombre_mozo']); ?></td>
+                                    <td><?php echo htmlspecialchars($order['numero_mesa'] ?? 'N/A'); ?></td>
+                                    <td><?php echo htmlspecialchars($order['nombre_mozo'] ?? 'N/A'); ?></td>
                                     <td>
                                         <span class="status status-<?php echo htmlspecialchars($order['estado']); ?>">
                                             <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $order['estado']))); ?>


### PR DESCRIPTION
This commit resolves an error on the order detail page that occurred when an associated table or waiter had been deleted.

The `sp_getAllOrders` and `sp_getOrderDetail` stored procedures have been updated to use `LEFT JOIN` instead of `INNER JOIN`. This makes the queries more robust, ensuring that order details can still be loaded even if the original table or waiter no longer exists in the database.

The frontend pages (`pedidos.php` and `pedido_detalle.php`) have also been updated to gracefully handle and display "N/A" if this associated data is missing.