### PR TITLE
fix: Resolve multi-procedure call error in PDO

### DIFF
--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -13,6 +13,7 @@ define('DB_DSN', 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8
 $pdo_options = [
     PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_EMULATE_PREPARES   => false,
+    // Se establece a true para resolver problemas con múltiples llamadas a SP en algunas configuraciones de MySQL/PHP
+    PDO::ATTR_EMULATE_PREPARES   => true,
 ];
 ?>


### PR DESCRIPTION
This commit fixes a critical bug that prevented the order detail page from loading. The error was caused by a known issue in some MySQL/PHP configurations where subsequent PDO `prepare` calls fail after a stored procedure call.

The fix is to set `PDO::ATTR_EMULATE_PREPARES` to `true` in the database connection options (`backend/config/database.php`). This changes how PDO communicates with the database and is the standard way to resolve this specific issue, ensuring that multiple stored procedures can be called reliably within the same request.