### PR TITLE
feat: Redesign order list page to use a card-based view

### DIFF
--- a/frontend_web/pedidos.php
+++ b/frontend_web/pedidos.php
@@ -11,8 +11,7 @@ include_once 'templates/header.php';
 
 function getOrders() {
     $api_url = 'http://localhost/restaurante_system/backend/api/v1/pedidos.php';
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $api_url);
+    $ch = curl_init($api_url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     $response = curl_exec($ch);
     curl_close($ch);
@@ -41,51 +40,91 @@ $orders_data = getOrders();
             }
             ?>
 
-            <div class="table-container">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>ID Pedido</th>
-                            <th>Mesa</th>
-                            <th>Mozo</th>
-                            <th>Estado</th>
-                            <th>Total</th>
-                            <th>Fecha</th>
-                            <th>Acciones</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if (isset($orders_data['records']) && !empty($orders_data['records'])): ?>
-                            <?php foreach ($orders_data['records'] as $order): ?>
-                                <tr>
-                                    <td>#<?php echo htmlspecialchars($order['id']); ?></td>
-                                    <td><?php echo htmlspecialchars($order['numero_mesa'] ?? 'N/A'); ?></td>
-                                    <td><?php echo htmlspecialchars($order['nombre_mozo'] ?? 'N/A'); ?></td>
-                                    <td>
-                                        <span class="status status-<?php echo htmlspecialchars($order['estado']); ?>">
-                                            <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $order['estado']))); ?>
-                                        </span>
-                                    </td>
-                                    <td>$<?php echo htmlspecialchars(number_format($order['total'], 2)); ?></td>
-                                    <td><?php echo htmlspecialchars(date("d/m/Y H:i", strtotime($order['fecha_creacion']))); ?></td>
-                                    <td class="actions-cell">
-                                        <a href="pedido_detalle.php?id=<?php echo $order['id']; ?>" class="btn-edit">Ver Detalle</a>
-                                    </td>
-                                </tr>
-                            <?php endforeach; ?>
-                        <?php else: ?>
-                            <tr>
-                                <td colspan="7">No se encontraron pedidos.</td>
-                            </tr>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
+            <div class="order-cards-container">
+                <?php if (isset($orders_data['records']) && !empty($orders_data['records'])): ?>
+                    <?php foreach ($orders_data['records'] as $order): ?>
+                        <div class="order-card">
+                            <div class="card-header">
+                                <strong>Pedido #<?php echo htmlspecialchars($order['id']); ?></strong>
+                                <span class="status status-<?php echo htmlspecialchars($order['estado']); ?>">
+                                    <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $order['estado']))); ?>
+                                </span>
+                            </div>
+                            <div class="card-body">
+                                <p><strong>Mesa:</strong> <?php echo htmlspecialchars($order['numero_mesa'] ?? 'N/A'); ?></p>
+                                <p><strong>Mozo:</strong> <?php echo htmlspecialchars($order['nombre_mozo'] ?? 'N/A'); ?></p>
+                                <p><strong>Fecha:</strong> <?php echo htmlspecialchars(date("d/m/Y H:i", strtotime($order['fecha_creacion']))); ?></p>
+                                <p class="total"><strong>Total:</strong> $<?php echo htmlspecialchars(number_format($order['total'], 2)); ?></p>
+                            </div>
+                            <div class="card-footer">
+                                <a href="pedido_detalle.php?id=<?php echo $order['id']; ?>" class="btn-card btn-view">Ver Detalle</a>
+                                <a href="pedido_detalle.php?id=<?php echo $order['id']; ?>" class="btn-card btn-edit">Editar</a>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <p>No se encontraron pedidos.</p>
+                <?php endif; ?>
             </div>
         </div>
     </main>
 </div>
 
 <style>
+.order-cards-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+}
+.order-card {
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    display: flex;
+    flex-direction: column;
+}
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 15px;
+    border-bottom: 1px solid var(--border-color);
+}
+.card-body {
+    padding: 15px;
+    flex-grow: 1;
+}
+.card-body p {
+    margin: 0 0 10px 0;
+}
+.card-body p.total {
+    margin-top: 15px;
+    font-size: 1.1em;
+}
+.card-footer {
+    padding: 10px 15px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    gap: 10px;
+}
+.btn-card {
+    flex-grow: 1;
+    text-align: center;
+    padding: 8px;
+    text-decoration: none;
+    border-radius: 5px;
+    color: #fff;
+    font-weight: 500;
+}
+.btn-view {
+    background-color: var(--secondary-color);
+}
+.btn-edit {
+    background-color: #ffc107;
+    color: #000;
+}
+
+/* Estilos de estado */
 .status {
     padding: 4px 8px;
     border-radius: 12px;
@@ -94,12 +133,12 @@ $orders_data = getOrders();
     color: #fff;
     text-transform: capitalize;
 }
-.status-recibido { background-color: #0d6efd; } /* Azul */
-.status-en_preparacion { background-color: #ffc107; color: #000; } /* Amarillo */
-.status-listo_para_servir { background-color: #fd7e14; } /* Naranja */
-.status-servido { background-color: #198754; } /* Verde */
-.status-pagado { background-color: #20c997; } /* Turquesa */
-.status-cancelado { background-color: #dc3545; } /* Rojo */
+.status-recibido { background-color: #0d6efd; }
+.status-en_preparacion { background-color: #ffc107; color: #000; }
+.status-listo_para_servir { background-color: #fd7e14; }
+.status-servido { background-color: #198754; }
+.status-pagado { background-color: #20c997; }
+.status-cancelado { background-color: #dc3545; }
 </style>
 
 <?php


### PR DESCRIPTION
This commit refactors the main "Pedidos" page (`pedidos.php`) from a table-based layout to a more modern, responsive card-based layout using CSS Grid.

Changes include:
- The `<table>` structure has been replaced with `<div>` elements styled as cards.
- Each card displays all relevant order information, including an order ID, table, waiter, status with color-coding, total, and date.
- An "Editar" (Edit) button has been added to each card alongside the "Ver Detalle" (View Detail) button, as per the user's request. Currently, the Edit button links to the detail page as a placeholder for future functionality.