### PR TITLE
fix: Make order detail page responsive

### DIFF
--- a/frontend_web/assets/css/style.css
+++ b/frontend_web/assets/css/style.css
@@ -496,4 +496,39 @@ body.sidebar-collapsed .mobile-overlay {
         text-align: left;
         padding-right: 1rem;
     }
+
+    /* Patrón de tabla responsive para el detalle de pedido */
+    #order-detail-items-table {
+        border: none;
+    }
+    #order-detail-items-table thead {
+        display: none;
+    }
+    #order-detail-items-table, #order-detail-items-table tbody, #order-detail-items-table tr, #order-detail-items-table td {
+        display: block;
+        width: 100%;
+    }
+    #order-detail-items-table tr {
+        margin-bottom: 15px;
+        border: 1px solid var(--border-color);
+        border-radius: 5px;
+    }
+    #order-detail-items-table td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        text-align: right;
+        border: none;
+        border-bottom: 1px solid var(--border-color);
+        padding: 10px 15px;
+    }
+    #order-detail-items-table td:last-child {
+        border-bottom: none;
+    }
+    #order-detail-items-table td::before {
+        content: attr(data-label);
+        font-weight: bold;
+        text-align: left;
+        padding-right: 1rem;
+    }
 }

--- a/frontend_web/pedido_detalle.php
+++ b/frontend_web/pedido_detalle.php
@@ -64,7 +64,7 @@ $order = getOrderDetails($order_id);
                     <div class="order-items">
                         <h3>Items del Pedido</h3>
                         <div class="table-container">
-                            <table>
+                            <table id="order-detail-items-table">
                                 <thead>
                                     <tr>
                                         <th>Producto</th>
@@ -76,10 +76,10 @@ $order = getOrderDetails($order_id);
                                 <tbody>
                                     <?php foreach ($order['items'] as $item): ?>
                                         <tr>
-                                            <td><?php echo htmlspecialchars($item['nombre_producto']); ?></td>
-                                            <td><?php echo htmlspecialchars($item['cantidad']); ?></td>
-                                            <td><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['precio_unitario'], 2)); ?></td>
-                                            <td><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['subtotal'], 2)); ?></td>
+                                            <td data-label="Producto"><?php echo htmlspecialchars($item['nombre_producto']); ?></td>
+                                            <td data-label="Cantidad"><?php echo htmlspecialchars($item['cantidad']); ?></td>
+                                            <td data-label="Precio Unit."><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['precio_unitario'], 2)); ?></td>
+                                            <td data-label="Subtotal"><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['subtotal'], 2)); ?></td>
                                         </tr>
                                     <?php endforeach; ?>
                                 </tbody>


### PR DESCRIPTION
This commit resolves a responsive layout issue on the "Order Detail" page (`pedido_detalle.php`).

The table displaying the list of items in an order was not responsive and did not display well on mobile devices.

This has been fixed by applying a responsive card pattern to the table using CSS. On screens smaller than 768px, each row in the table now reflows into a card-like block, with data labels for clarity. This ensures all order item details are visible and usable on any device.