### PR TITLE
fix: Implement card view for items on mobile order form

### DIFF
--- a/frontend_web/assets/css/style.css
+++ b/frontend_web/assets/css/style.css
@@ -531,4 +531,58 @@ body.sidebar-collapsed .mobile-overlay {
         text-align: left;
         padding-right: 1rem;
     }
+    #order-items-table td input.item-quantity {
+        width: 50px; /* Ancho fijo pero pequeño */
+        text-align: center;
+    }
+    #order-items-table td .btn-delete {
+        padding: 5px 8px;
+        font-size: 0.9em;
+    }
+
+    /* --- Clases para mostrar/ocultar en móvil/desktop --- */
+    .desktop-only {
+        display: none !important;
+    }
+    .mobile-only {
+        display: block !important;
+    }
+
+    /* --- Estilos para las tarjetas de items de pedido en móvil --- */
+    .order-item-card {
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 10px;
+        margin-bottom: 10px;
+        background-color: #fdfdfd;
+    }
+    .card-item-header {
+        font-weight: bold;
+        margin-bottom: 10px;
+        padding-bottom: 5px;
+        border-bottom: 1px solid var(--border-color);
+    }
+    .card-item-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+        font-size: 0.95em;
+    }
+    .card-item-row span:first-child {
+        font-weight: 500;
+        color: #555;
+    }
+    .card-item-footer {
+        margin-top: 10px;
+        text-align: right;
+    }
+    .card-item-footer .btn-delete {
+        padding: 5px 10px;
+        font-size: 0.9em;
+    }
+}
+
+.mobile-only {
+    display: none !important;
 }

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -107,7 +107,8 @@ if (isset($_GET['id'])) {
                         </div>
                         <?php endif; ?>
 
-                        <div class="table-container">
+                        <!-- Vista de Tabla para Desktop -->
+                        <div class="table-container desktop-only">
                             <table id="order-items-table">
                                 <thead>
                                     <tr>
@@ -118,15 +119,18 @@ if (isset($_GET['id'])) {
                                         <th></th>
                                     </tr>
                                 </thead>
-                                <tbody></tbody>
-                                <tfoot>
-                                    <tr>
-                                        <td colspan="3" style="text-align: right;"><strong>Total:</strong></td>
-                                        <td id="order-total" style="font-weight: bold;">$0.00</td>
-                                        <td></td>
-                                    </tr>
-                                </tfoot>
+                                <tbody><!-- Rellenado con JS --></tbody>
                             </table>
+                        </div>
+
+                        <!-- Vista de Tarjetas para Móvil -->
+                        <div id="order-items-cards" class="mobile-only">
+                            <!-- Rellenado con JS -->
+                        </div>
+
+                        <div class="order-total-container">
+                            <strong>Total:</strong>
+                            <span id="order-total" style="font-weight: bold;">$0.00</span>
                         </div>
 
                         <div class="form-actions" style="margin-top: 20px;">
@@ -221,44 +225,81 @@ document.addEventListener('DOMContentLoaded', function() {
         } else {
             currentOrder[productId] = { id: productId, nombre: productItem.dataset.nombre, precio: parseFloat(productItem.dataset.precio), cantidad: 1 };
         }
-        renderOrderTable();
+        renderOrderItems();
     });
-    orderItemsTableBody.addEventListener('click', function(e) {
-        if (e.target.classList.contains('delete-item')) {
-            delete currentOrder[e.target.dataset.id];
-            renderOrderTable();
-        }
-    });
-    orderItemsTableBody.addEventListener('input', function(e) {
+
+    // Un solo event listener en el contenedor de detalles para manejar clicks e inputs
+    document.getElementById('order-details').addEventListener('input', function(e) {
         if (e.target.classList.contains('item-quantity')) {
             const newQuantity = parseInt(e.target.value, 10);
+            const productId = e.target.dataset.id;
             if (newQuantity > 0) {
-                currentOrder[e.target.dataset.id].cantidad = newQuantity;
+                currentOrder[productId].cantidad = newQuantity;
             } else {
-                delete currentOrder[e.target.dataset.id];
+                delete currentOrder[productId];
             }
-            renderOrderTable();
+            renderOrderItems();
         }
     });
-    function renderOrderTable() {
-        orderItemsTableBody.innerHTML = '';
+
+    document.getElementById('order-details').addEventListener('click', function(e) {
+        if (e.target.classList.contains('delete-item')) {
+            delete currentOrder[e.target.dataset.id];
+            renderOrderItems();
+        }
+    });
+
+    function renderOrderItems() {
+        const tableBody = document.querySelector('#order-items-table tbody');
+        const cardsContainer = document.getElementById('order-items-cards');
+        tableBody.innerHTML = '';
+        cardsContainer.innerHTML = '';
         let total = 0;
+
         for (const productId in currentOrder) {
             const item = currentOrder[productId];
             const subtotal = item.precio * item.cantidad;
             total += subtotal;
+
+            // Render Table Row (Desktop)
             const row = document.createElement('tr');
             row.innerHTML = `
-                <td data-label="Producto">${item.nombre}</td>
-                <td data-label="Cantidad"><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></td>
-                <td data-label="Precio">${currencySymbol}${item.precio.toFixed(2)}</td>
-                <td data-label="Subtotal">${currencySymbol}${subtotal.toFixed(2)}</td>
-                <td data-label="Acción"><button type="button" class="btn-delete delete-item" data-id="${item.id}">X</button></td>
+                <td>${item.nombre}</td>
+                <td><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></td>
+                <td>${currencySymbol}${item.precio.toFixed(2)}</td>
+                <td>${currencySymbol}${subtotal.toFixed(2)}</td>
+                <td><button type="button" class="btn-delete delete-item" data-id="${item.id}">X</button></td>
             `;
-            orderItemsTableBody.appendChild(row);
+            tableBody.appendChild(row);
+
+            // Render Card (Mobile)
+            const card = document.createElement('div');
+            card.className = 'order-item-card';
+            card.innerHTML = `
+                <div class="card-item-header">${item.nombre}</div>
+                <div class="card-item-body">
+                    <div class="card-item-row">
+                        <span>Precio:</span>
+                        <span>${currencySymbol}${item.precio.toFixed(2)}</span>
+                    </div>
+                    <div class="card-item-row">
+                        <span>Cantidad:</span>
+                        <input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}">
+                    </div>
+                    <div class="card-item-row">
+                        <span>Subtotal:</span>
+                        <span>${currencySymbol}${subtotal.toFixed(2)}</span>
+                    </div>
+                </div>
+                <div class="card-item-footer">
+                    <button type="button" class="btn-delete delete-item" data-id="${item.id}">Eliminar</button>
+                </div>
+            `;
+            cardsContainer.appendChild(card);
         }
         orderTotalElement.textContent = `${currencySymbol}${total.toFixed(2)}`;
     }
+
     productSearch.addEventListener('keyup', function() {
         const searchTerm = productSearch.value.toLowerCase();
         document.querySelectorAll('#product-list .product-item').forEach(item => {


### PR DESCRIPTION
This commit resolves a persistent responsive layout issue on the "Create/Edit Order" page (`pedido_form.php`). The previous responsive table implementation was not sufficient and did not meet the user's request for a card-based layout.

Changes include:
- A new container for a card-based view of order items has been added to `pedido_form.php`, which is shown only on mobile.
- The existing table view is now hidden on mobile.
- The JavaScript `renderOrderItems` function has been updated to populate both the desktop table and the new mobile card view.
- New CSS has been added to `style.css` to style the item cards and handle the visibility toggle between the two views.