### PR TITLE
Feat: Guardado automático al cambiar estado del pedido

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -211,7 +211,9 @@ document.addEventListener('DOMContentLoaded', function() {
         button.addEventListener('click', function() {
             const newStatus = this.dataset.status;
             estadoInput.value = newStatus;
-            orderForm.dispatchEvent(new Event('submit', { cancelable: true }));
+            // requestSubmit() es una forma más robusta de activar el envío del formulario
+            // programáticamente, asegurando que el evento 'submit' se dispare.
+            orderForm.requestSubmit();
         });
     });
 


### PR DESCRIPTION
- Se ha modificado el comportamiento de los botones de acción rápida ('Abierto', 'Completado', 'Cancelado') en el formulario de edición de pedidos.
- Al hacer clic en uno de estos botones, el formulario ahora se guarda automáticamente con el nuevo estado.
- Se ha mejorado el script del lado del cliente utilizando `requestSubmit()` para un envío de formulario más robusto y fiable.