### PR TITLE
fix(pedidos): Cargar detalles del pedido desde la API en el formulari…

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -41,11 +41,15 @@ if (isset($_GET['id'])) {
     $is_editing = true;
     $order_id = intval($_GET['id']);
     $page_title = "Editar Pedido #$order_id";
-    // Simulo datos de un pedido existente
-    $order_data = [
-        'id_mesa' => 1, 'id_usuario_mozo' => 1, 'estado' => 'recibido',
-        'items' => [['id_producto' => 1, 'nombre_producto' => 'Pizza', 'precio_unitario' => 10.50, 'cantidad' => 2]]
-    ];
+    // Obtener datos reales del pedido desde la API
+    $order_data = fetchFromAPI("pedidos.php?id=$order_id");
+    if (isset($order_data['error'])) {
+        // Manejar el error, por ejemplo, mostrando un mensaje y saliendo
+        echo "Error al cargar el pedido: " . htmlspecialchars($order_data['error']);
+        // O redirigir a la lista de pedidos con un mensaje de error
+        // header('Location: pedidos.php?error=' . urlencode($order_data['error']));
+        exit;
+    }
 }
 
 $mesas_data = fetchFromAPI('mesas.php');


### PR DESCRIPTION
…o de edición

El formulario de edición de pedidos (`pedido_form.php`) utilizaba datos simulados en lugar de obtener los detalles reales del pedido desde la API. Esto provocaba que, al editar un pedido, no se mostraran los artículos existentes.

Este cambio reemplaza los datos simulados con una llamada a la API (`pedidos.php?id={order_id}`) para obtener y mostrar correctamente los detalles del pedido que se está editando.