### PR TITLE
fix(templates): Corregir ruta de inclusión en header.php

### DIFF
--- a/frontend_web/templates/header.php
+++ b/frontend_web/templates/header.php
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="assets/css/modal.css?v=<?php echo time(); ?>">
 </head>
 <body id="page-body">
-<?php include_once 'modal_alert.php'; ?>
+<?php include_once __DIR__ . '/modal_alert.php'; ?>
 <div class="page-wrapper">
 <header class="mobile-header">
     <a href="dashboard.php" class="logo">


### PR DESCRIPTION
La inclusión de 'modal_alert.php' utilizaba una ruta relativa, lo que causaba un error fatal ('failed to open stream') en todas las páginas del sitio.

Este cambio corrige la ruta utilizando la constante mágica '__DIR__' para crear una ruta absoluta, asegurando que el archivo se encuentre siempre, independientemente de la página que lo incluya.