### PR TITLE
Fix: Create missing modal files to prevent fatal error

### DIFF
--- a/frontend_web/assets/css/modal.css
+++ b/frontend_web/assets/css/modal.css
@@ -1,0 +1,65 @@
+/* Estilos para el modal de alertas */
+.modal-overlay {
+    display: none; /* Oculto por defecto */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    z-index: 1050;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-content {
+    position: relative;
+    background-color: #fff;
+    padding: 25px;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+    width: 90%;
+    max-width: 500px;
+    animation: slide-down 0.3s ease-out;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #dee2e6;
+    padding-bottom: 15px;
+    margin-bottom: 15px;
+}
+
+.modal-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.modal-close {
+    background: transparent;
+    border: none;
+    font-size: 1.8rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+}
+
+.modal-body {
+    font-size: 1rem;
+    color: #495057;
+}
+
+/* Animación para el modal */
+@keyframes slide-down {
+    from {
+        transform: translateY(-30px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}

--- a/frontend_web/templates/modal_alert.php
+++ b/frontend_web/templates/modal_alert.php
@@ -1,0 +1,34 @@
+<!-- Modal de Alerta Genérico -->
+<div id="alertModal" class="modal-overlay">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h5 id="alertModalTitle" class="modal-title">Alerta</h5>
+            <button type="button" class="modal-close" onclick="closeAlertModal()">
+                <i class="bi bi-x-lg"></i>
+            </button>
+        </div>
+        <div class="modal-body">
+            <p id="alertModalMessage"></p>
+        </div>
+    </div>
+</div>
+
+<script>
+function showAlert(title, message) {
+    document.getElementById('alertModalTitle').textContent = title;
+    document.getElementById('alertModalMessage').textContent = message;
+    document.getElementById('alertModal').style.display = 'flex';
+}
+
+function closeAlertModal() {
+    document.getElementById('alertModal').style.display = 'none';
+}
+
+// Cerrar el modal si se hace clic fuera del contenido
+window.addEventListener('click', function(event) {
+    const modal = document.getElementById('alertModal');
+    if (event.target === modal) {
+        closeAlertModal();
+    }
+});
+</script>


### PR DESCRIPTION
The application was throwing a fatal PHP error on the orders page because `frontend_web/templates/header.php` was trying to include a non-existent file: `frontend_web/templates/modal_alert.php`.

This commit resolves the error by:
1.  Creating the `frontend_web/templates/modal_alert.php` file with the necessary HTML and JavaScript for a generic alert modal.
2.  Creating the corresponding stylesheet `frontend_web/assets/css/modal.css` to ensure the modal is styled correctly.

The `header.php` file already contained the necessary `include` for the PHP file and the `<link>` for the CSS file, so no other changes were needed.