### PR TITLE
Fix: Correct reservation status values and improve error logging

### DIFF
--- a/backend/models/Reservation.php
+++ b/backend/models/Reservation.php
@@ -70,6 +70,8 @@ class Reservation {
         if($stmt->execute()) {
             return true;
         }
+        // Log error if execution fails
+        error_log("Database error on create: " . implode(" - ", $stmt->errorInfo()));
         return false;
     }
 
@@ -110,6 +112,8 @@ class Reservation {
         if($stmt->execute()) {
             return true;
         }
+        // Log error if execution fails
+        error_log("Database error on update: " . implode(" - ", $stmt->errorInfo()));
         return false;
     }
 

--- a/frontend_web/reserva_form.php
+++ b/frontend_web/reserva_form.php
@@ -39,7 +39,7 @@ if (isset($_GET['id'])) {
 
 $mesas_data = fetchFromAPI('mesas.php');
 $mesas = $mesas_data['records'] ?? [];
-$reservation_states = ['confirmada', 'asistió', 'cancelada', 'no-show'];
+$reservation_states = ['confirmada', 'completada', 'cancelada'];
 
 ?>
 


### PR DESCRIPTION
This commit fixes a bug where creating or updating a reservation would fail due to a mismatch between the status values in the form and the allowed ENUM values in the database.

- Corrected the `$reservation_states` array in `frontend_web/reserva_form.php` to use `['confirmada', 'completada', 'cancelada']`, matching the database schema.
- Added detailed error logging to the `create()` and `update()` methods in `backend/models/Reservation.php`. If a database query fails, the specific error will now be logged, making future debugging easier.