### PR TITLE
Fix: Define API_BASE_URL constant to prevent fatal error

### DIFF
--- a/backend/config/app_config.php
+++ b/backend/config/app_config.php
@@ -9,5 +9,8 @@
 // Ejemplos: '$', '€', 'S/'
 define('CURRENCY_SYMBOL', 'S/.');
 
+// Define la URL base para la API. Asegúrate de que termine con una barra inclinada (/).
+define('API_BASE_URL', 'http://localhost/restaurante_system/backend/api/v1/');
+
 // Aquí se pueden añadir otras configuraciones globales en el futuro.
 ?>

--- a/frontend_web/reserva_handler.php
+++ b/frontend_web/reserva_handler.php
@@ -7,6 +7,11 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
 
 include_once __DIR__ . '/../backend/config/app_config.php';
 
+// Salvaguarda por si la constante no está definida en el archivo de configuración.
+if (!defined('API_BASE_URL')) {
+    define('API_BASE_URL', 'http://localhost/restaurante_system/backend/api/v1/');
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $api_url = API_BASE_URL . 'reservas.php';
     $is_editing = isset($_POST['id']) && !empty($_POST['id']);


### PR DESCRIPTION
This commit fixes a fatal error in `reserva_handler.php` caused by the use of an undefined constant, `API_BASE_URL`.

- Defines `API_BASE_URL` in the central configuration file, `backend/config/app_config.php`, to ensure it is available globally.
- Adds a fallback definition in `frontend_web/reserva_handler.php` to make the script more robust against configuration issues.

This resolves the 'undefined constant' warning and the subsequent 'header may not contain more than a single header' error when saving a reservation.