### PR TITLE
Fix: Refactor INSERT query to improve database compatibility

### DIFF
--- a/backend/models/Reservation.php
+++ b/backend/models/Reservation.php
@@ -44,7 +44,7 @@ class Reservation {
     }
 
     function create() {
-        $query = "INSERT INTO " . $this->table_name . " SET id_mesa=:id_mesa, nombre_cliente=:nombre_cliente, telefono_cliente=:telefono_cliente, email_cliente=:email_cliente, fecha_reserva=:fecha_reserva, cantidad_personas=:cantidad_personas, estado=:estado, observaciones=:observaciones";
+        $query = "INSERT INTO " . $this->table_name . " (id_mesa, nombre_cliente, telefono_cliente, email_cliente, fecha_reserva, cantidad_personas, estado, observaciones) VALUES (:id_mesa, :nombre_cliente, :telefono_cliente, :email_cliente, :fecha_reserva, :cantidad_personas, :estado, :observaciones)";
         $stmt = $this->conn->prepare($query);
 
         // Sanitize


### PR DESCRIPTION
This commit addresses a bug where new reservations were failing to save silently.

The `INSERT` query in the `Reservation` model's `create()` method has been changed from the `INSERT ... SET` syntax to the more standard and widely-compatible `INSERT INTO ... VALUES (...)` syntax. This should prevent potential issues with different database versions or configurations that might not fully support the former syntax, resolving the silent save failure.