### PR TITLE
Fix: Remove non-existent modal.js script tag

### DIFF
--- a/frontend_web/templates/footer.php
+++ b/frontend_web/templates/footer.php
@@ -26,6 +26,5 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 </script>
-<script src="assets/js/modal.js?v=<?php echo time(); ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit removes a `<script>` tag from `footer.php` that was attempting to load `assets/js/modal.js`. This file does not exist, which was causing a 404 Not Found error in the browser's network console.

The JavaScript logic for the modal is already correctly included via `modal_alert.php`, so this script tag was unnecessary. Removing it resolves the 404 error without affecting functionality.