### PR TITLE
Fix: Use Singleton pattern to get database connection

### DIFF
--- a/backend/models/Reservation.php
+++ b/backend/models/Reservation.php
@@ -14,8 +14,7 @@ class Reservation {
     public $observaciones;
 
     public function __construct() {
-        $database = new Database();
-        $this->conn = $database->getConnection();
+        $this->conn = Database::getInstance();
     }
 
     function readAll() {


### PR DESCRIPTION
This commit fixes a fatal error, `Call to private Database::__construct()`, that occurred when creating a `Reservation` object.

The `Database` class is implemented as a Singleton, but the `Reservation` model's constructor was incorrectly trying to instantiate it directly with `new Database()`.

The fix updates the constructor in `backend/models/Reservation.php` to use the correct static method, `Database::getInstance()`, to retrieve the database connection. This aligns the model with the application's established database connection pattern and resolves the fatal error.