### PR TITLE
fix: Correct product visibility regression

### DIFF
--- a/backend/models/Product.php
+++ b/backend/models/Product.php
@@ -27,7 +27,14 @@ class Product {
         $estado = $filters['estado'] ?? null;
 
         // Enlazar parámetros
-        $this->bindAllParams($stmt, $filters, ['page' => $page, 'page_size' => $page_size]);
+        $stmt->bindValue(':id', $id, $id === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->bindValue(':nombre', $nombre, $nombre === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':descripcion', $descripcion, $descripcion === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':precio', $precio, $precio === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':categoria_nombre', $categoria_nombre, $categoria_nombre === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':estado', $estado, $estado === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':page_number', $page, PDO::PARAM_INT);
+        $stmt->bindValue(':page_size', $page_size, PDO::PARAM_INT);
 
         $stmt->execute();
         return $stmt;
@@ -37,45 +44,25 @@ class Product {
         $query = "CALL sp_countAllProducts(:id, :nombre, :descripcion, :precio, :categoria_nombre, :estado)";
         $stmt = $this->conn->prepare($query);
 
-        // Enlazar parámetros
-        $this->bindAllParams($stmt, $filters);
-
-        $stmt->execute();
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row['total_records'];
-    }
-
-    private function bindAllParams($stmt, $filters, $pagination = []) {
+        // Asignar valores de los filtros, usando null si no están definidos
         $id = $filters['id'] ?? null;
         $nombre = $filters['nombre'] ?? null;
         $descripcion = $filters['descripcion'] ?? null;
         $precio = $filters['precio'] ?? null;
         $categoria_nombre = $filters['categoria_nombre'] ?? null;
         $estado = $filters['estado'] ?? null;
-        $page = $pagination['page'] ?? null;
-        $page_size = $pagination['page_size'] ?? null;
 
-        $this->bindParamIfValue($stmt, ':id', $id, PDO::PARAM_INT);
-        $this->bindParamIfValue($stmt, ':nombre', $nombre, PDO::PARAM_STR);
-        $this->bindParamIfValue($stmt, ':descripcion', $descripcion, PDO::PARAM_STR);
-        $this->bindParamIfValue($stmt, ':precio', $precio, PDO::PARAM_STR);
-        $this->bindParamIfValue($stmt, ':categoria_nombre', $categoria_nombre, PDO::PARAM_STR);
-        $this->bindParamIfValue($stmt, ':estado', $estado, PDO::PARAM_STR);
+        // Enlazar parámetros
+        $stmt->bindValue(':id', $id, $id === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->bindValue(':nombre', $nombre, $nombre === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':descripcion', $descripcion, $descripcion === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':precio', $precio, $precio === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':categoria_nombre', $categoria_nombre, $categoria_nombre === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':estado', $estado, $estado === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
 
-        if ($page !== null) {
-            $stmt->bindParam(':page_number', $page, PDO::PARAM_INT);
-        }
-        if ($page_size !== null) {
-            $stmt->bindParam(':page_size', $page_size, PDO::PARAM_INT);
-        }
-    }
-
-    private function bindParamIfValue($stmt, $param, $value, $type) {
-        if ($value !== null) {
-            $stmt->bindParam($param, $value, $type);
-        } else {
-            $stmt->bindValue($param, null, PDO::PARAM_NULL);
-        }
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row['total_records'];
     }
 
     /**


### PR DESCRIPTION
This commit fixes a critical bug where products were not being displayed in the product catalog. The issue was caused by incorrect PDO parameter binding in the `Product` model, which has now been resolved.

- Replaces `bindParam` with `bindValue` in `backend/models/Product.php` to ensure correct parameter evaluation and prevent issues with variable scope. This resolves the product visibility issue.
- Optimizes the category filter query in the stored procedures to use an equality check instead of LIKE.
- Implements pagination for the product catalog.
- Changes the category filter to a dropdown menu.
- Removes the site-wide footer.