### PR TITLE
Debug: Add cURL error logging to login handler

### DIFF
--- a/frontend_web/login_handler.php
+++ b/frontend_web/login_handler.php
@@ -24,6 +24,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['username']) && isset($
     // Ejecutar la petición y obtener la respuesta
     $response = curl_exec($ch);
     $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+    // --- INICIO DEPURACIÓN cURL ---
+    if (curl_errno($ch)) {
+        $error_log_file = '/tmp/curl_errors.log';
+        $timestamp = date('Y-m-d H:i:s');
+        $log_message = "--- ERROR cURL [$timestamp] ---\n";
+        $log_message .= "Error: " . curl_error($ch) . "\n";
+        $log_message .= "URL: " . $api_url . "\n\n";
+        file_put_contents($error_log_file, $log_message, FILE_APPEND);
+    }
+    // --- FIN DEPURACIÓN cURL ---
+
     curl_close($ch);
 
     // Decodificar la respuesta JSON


### PR DESCRIPTION
- Added temporary debugging code to `frontend_web/login_handler.php`.
- If the cURL request to the API fails, it will now log the specific cURL error to `/tmp/curl_errors.log`.
- This is to diagnose why the backend API script appears to be unreachable from the frontend.