### PR TITLE
Fix: Trim whitespace from login credentials

### DIFF
--- a/backend/api/v1/login.php
+++ b/backend/api/v1/login.php
@@ -14,40 +14,26 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit();
 }
 
-// --- INICIO CÓDIGO DE DEPURACIÓN ---
-$debug_log_file = '/tmp/login_debug.log'; // Usar un directorio temporal escribible
-$raw_input = file_get_contents("php://input");
-$post_data = print_r($_POST, true);
-$timestamp = date('Y-m-d H:i:s');
-$log_message = "--- INICIO DEPURACIÓN [$timestamp] ---\n";
-$log_message .= "RAW INPUT:\n" . $raw_input . "\n\n";
-$log_message .= "DATOS \$_POST:\n" . $post_data . "\n\n";
-// --- FIN CÓDIGO DE DEPURACIÓN ---
-
 // Obtener los datos enviados
 // Primero intenta decodificar el cuerpo JSON
-$data = json_decode($raw_input);
+$data = json_decode(file_get_contents("php://input"));
 
 // Si el cuerpo JSON está vacío o no es un objeto, intenta obtener los datos de $_POST
-// Esto da flexibilidad para aceptar tanto application/json como application/x-www-form-urlencoded
 if (!is_object($data) && isset($_POST['username'])) {
     // Convertir el array $_POST a un objeto para mantener una estructura de datos consistente
     $data = (object)$_POST;
 }
 
-// --- INICIO CÓDIGO DE DEPURACIÓN (PARTE 2) ---
-$final_data = print_r($data, true);
-$log_message .= "DATOS FINALES (\$data):\n" . $final_data . "\n\n";
-$log_message .= "--- FIN DEPURACIÓN ---\n\n";
-file_put_contents($debug_log_file, $log_message, FILE_APPEND);
-// --- FIN CÓDIGO DE DEPURACIÓN (PARTE 2) ---
-
-// Validar que se recibieron los datos necesarios
+// Validar que se recibieron los datos necesarios y limpiarlos
 if (empty($data->username) || empty($data->password)) {
     http_response_code(400); // Bad Request
     echo json_encode(array("message" => "No se pudo iniciar sesión. Faltan el nombre de usuario o la contraseña."));
     exit();
 }
+
+// Limpiar los datos de entrada para eliminar espacios en blanco accidentales
+$data->username = trim($data->username);
+$data->password = trim($data->password);
 
 $user = new User();
 

--- a/frontend_web/login_handler.php
+++ b/frontend_web/login_handler.php
@@ -24,18 +24,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['username']) && isset($
     // Ejecutar la petición y obtener la respuesta
     $response = curl_exec($ch);
     $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-    // --- INICIO DEPURACIÓN cURL ---
-    if (curl_errno($ch)) {
-        $error_log_file = '/tmp/curl_errors.log';
-        $timestamp = date('Y-m-d H:i:s');
-        $log_message = "--- ERROR cURL [$timestamp] ---\n";
-        $log_message .= "Error: " . curl_error($ch) . "\n";
-        $log_message .= "URL: " . $api_url . "\n\n";
-        file_put_contents($error_log_file, $log_message, FILE_APPEND);
-    }
-    // --- FIN DEPURACIÓN cURL ---
-
     curl_close($ch);
 
     // Decodificar la respuesta JSON


### PR DESCRIPTION
- The root cause of the 'Incorrect credentials' error was identified as potential leading/trailing whitespace in the submitted password.
- Added `trim()` to both username and password in `backend/api/v1/login.php` to sanitize the input before verification.
- Removed all temporary debugging code from `frontend_web/login_handler.php` and `backend/api/v1/login.php`.