### PR TITLE
Fix: Define CURRENCY_SYMBOL in frontend config

### DIFF
--- a/frontend_web/config.php
+++ b/frontend_web/config.php
@@ -5,5 +5,8 @@
  * Archivo de configuración para el frontend web.
  */
 
+// Define el símbolo de la moneda que se usará en la interfaz de usuario.
+define('CURRENCY_SYMBOL', 'S/.');
+
 // Define la URL base para la API. Asegúrate de que termine con una barra inclinada (/).
 define('API_BASE_URL', 'http://localhost/restaurante_system/backend/api/v1/');


### PR DESCRIPTION
- The `CURRENCY_SYMBOL` constant was missing from `frontend_web/config.php`, causing an 'undefined constant' error on pages that display prices.
- This commit adds the `CURRENCY_SYMBOL` definition to the frontend configuration file, resolving the error.