### PR TITLE
feat: Restructure sidebar into multi-level menu

### DIFF
--- a/frontend_web/assets/css/style.css
+++ b/frontend_web/assets/css/style.css
@@ -58,6 +58,31 @@ body.sidebar-collapsed .logo .text, body.sidebar-collapsed .sidebar ul li a .tex
 body.sidebar-collapsed .sidebar ul li a, body.sidebar-collapsed .sidebar-footer .user-info, body.sidebar-collapsed .sidebar-footer .logout-link { justify-content: center; }
 body.sidebar-collapsed .sidebar ul li a .icon, body.sidebar-collapsed .sidebar-footer .user-info .icon { margin-right: 0; }
 
+/* Submenu Styles */
+.sidebar ul li.has-submenu > a {
+    position: relative;
+}
+.sidebar ul li.has-submenu .arrow {
+    position: absolute;
+    right: 15px;
+    transition: transform 0.3s ease;
+}
+.sidebar ul li.has-submenu.active > a .arrow {
+    transform: rotate(180deg);
+}
+.sidebar ul .submenu {
+    list-style-type: none;
+    padding-left: 20px; /* Indentación para submenús */
+    display: none; /* Ocultos por defecto */
+}
+.sidebar ul .submenu li a {
+    padding: 10px 10px 10px 15px; /* Ajuste de padding para items de submenú */
+    font-size: 0.95em;
+}
+.sidebar ul .submenu li a .icon {
+    display: none; /* Ocultar icono en submenús */
+}
+
 /* Tabla y Tarjetas */
 .table-container { background-color: #fff; border-radius: 8px; box-shadow: 0 2px 5px rgba(0,0,0,0.1); padding: 20px; margin-top: 20px; overflow-x: auto; }
 table { width: 100%; border-collapse: collapse; }

--- a/frontend_web/templates/sidebar.php
+++ b/frontend_web/templates/sidebar.php
@@ -8,14 +8,36 @@
     </div>
     <ul>
         <li><a href="dashboard.php"><i class="bi bi-house-door-fill icon"></i> <span class="text">Inicio</span></a></li>
-        <li><a href="caja.php"><i class="bi bi-cash-stack icon"></i> <span class="text">Caja</span></a></li>
-        <li><a href="apertura_cierre.php"><i class="bi bi-door-closed-fill icon"></i> <span class="text">Apertura / Cierre</span></a></li>
-        <li><a href="pedidos.php"><i class="bi bi-receipt-cutoff icon"></i> <span class="text">Pedidos</span></a></li>
-        <li><a href="reservas.php"><i class="bi bi-calendar-check-fill icon"></i> <span class="text">Reservas</span></a></li>
-        <li><a href="productos.php"><i class="bi bi-box-seam-fill icon"></i> <span class="text">Productos</span></a></li>
-        <li><a href="categorias.php"><i class="bi bi-tag-fill icon"></i> <span class="text">Categorías</span></a></li>
-        <li><a href="mesas.php"><i class="bi bi-tablet-landscape-fill icon"></i> <span class="text">Mesas</span></a></li>
-        <li><a href="reportes_dinamicos.php"><i class="bi bi-file-earmark-bar-graph-fill icon"></i> <span class="text">Reportes Dinamicos</span></a></li>
+
+        <!-- Menu Maestros -->
+        <li class="has-submenu">
+            <a href="#" class="menu-toggle"><i class="bi bi-folder-fill icon"></i> <span class="text">Maestros</span><i class="bi bi-chevron-down arrow"></i></a>
+            <ul class="submenu">
+                <li><a href="productos.php"><span class="text">Productos</span></a></li>
+                <li><a href="categorias.php"><span class="text">Categorías</span></a></li>
+                <li><a href="mesas.php"><span class="text">Mesas</span></a></li>
+            </ul>
+        </li>
+
+        <!-- Menu Operaciones -->
+        <li class="has-submenu">
+            <a href="#" class="menu-toggle"><i class="bi bi-gear-fill icon"></i> <span class="text">Operaciones</span><i class="bi bi-chevron-down arrow"></i></a>
+            <ul class="submenu">
+                <li><a href="caja.php"><span class="text">Caja</span></a></li>
+                <li><a href="apertura_cierre.php"><span class="text">Apertura / Cierre</span></a></li>
+                <li><a href="pedidos.php"><span class="text">Pedidos</span></a></li>
+                <li><a href="reservas.php"><span class="text">Reservas</span></a></li>
+            </ul>
+        </li>
+
+        <!-- Menu Reportes -->
+        <li class="has-submenu">
+            <a href="#" class="menu-toggle"><i class="bi bi-graph-up icon"></i> <span class="text">Reportes</span><i class="bi bi-chevron-down arrow"></i></a>
+            <ul class="submenu">
+                <li><a href="reportes_dinamicos.php"><span class="text">Reportes Dinamicos</span></a></li>
+            </ul>
+        </li>
+
         <?php if (isset($_SESSION['user_rol']) && $_SESSION['user_rol'] == 'Administrador'): ?>
             <li><a href="usuarios.php"><i class="bi bi-people-fill icon"></i> <span class="text">Usuarios</span></a></li>
         <?php endif; ?>
@@ -28,3 +50,33 @@
         <a href="logout.php" class="logout-link"><i class="bi bi-box-arrow-right icon"></i> <span class="text">Cerrar Sesión</span></a>
     </div>
 </nav>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const menuToggles = document.querySelectorAll('.menu-toggle');
+
+    menuToggles.forEach(toggle => {
+        toggle.addEventListener('click', function(e) {
+            e.preventDefault();
+            const parentLi = this.parentElement;
+            const submenu = parentLi.querySelector('.submenu');
+
+            if (submenu) {
+                if (submenu.style.display === 'block') {
+                    submenu.style.display = 'none';
+                    parentLi.classList.remove('active');
+                } else {
+                    // Opcional: cerrar otros submenús abiertos
+                    document.querySelectorAll('.has-submenu.active').forEach(openMenu => {
+                        openMenu.classList.remove('active');
+                        openMenu.querySelector('.submenu').style.display = 'none';
+                    });
+
+                    submenu.style.display = 'block';
+                    parentLi.classList.add('active');
+                }
+            }
+        });
+    });
+});
+</script>


### PR DESCRIPTION
Restructures the sidebar into a multi-level, collapsible menu with 'Maestros', 'Operaciones', and 'Reportes' as top-level items. Adds custom JavaScript and CSS to handle the collapse/expand functionality. Only top-level menus have icons, as requested.