### PR TITLE
Hotfix: Corrige error de sintaxis en `pedido_form.php`

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -129,7 +129,7 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
                                     $is_selectable = $is_available || $is_selected;
                                 ?>
                                     <option value="<?php echo $mesa['id']; ?>" <?php if ($is_selected) echo 'selected'; ?> <?php if (!$is_selectable) echo 'disabled'; ?>>
-                                        <?php echo htmlspecialchars($mesa['numero_mesa']); ?> (<?php echo htmlspecialchars(ucfirst($mesa['estado']))); ?>)
+                                        <?php echo htmlspecialchars($mesa['numero_mesa'] . ' (' . ucfirst($mesa['estado']) . ')'); ?>
                                     </option>
                                 <?php endforeach; ?>
                             </select>


### PR DESCRIPTION
Este commit soluciona un error de sintaxis (PHP Parse error) que ocurría en la página de edición de pedidos.

El error fue causado por una construcción de `echo` incorrecta al mostrar el nombre y estado de la mesa en el desplegable. Se ha refactorizado la línea para usar un único `echo` y una concatenación adecuada, lo que resuelve el problema de parsing.