### PR TITLE
Feat(pedido): Añade botón "Volver a Lista" al formulario de pedidos

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -161,6 +161,7 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
                         <?php endif; ?>
                         
                         <div class="form-actions">
+                            <a href="pedidos.php" class="btn btn-secondary">Volver a Lista</a>
                             <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar' : 'Crear'; ?> Pedido</button>
                         </div>
                     </form>


### PR DESCRIPTION
Este commit introduce una mejora de usabilidad en el formulario de creación y edición de pedidos (`pedido_form.php`).

Se ha añadido un botón "Volver a Lista" junto al botón de acción principal (Crear/Actualizar Pedido). Este botón permite a los usuarios navegar de vuelta a la página del listado de pedidos (`pedidos.php`) de forma rápida y sin guardar ningún cambio, cancelando así la operación actual.

El botón utiliza la clase `btn-secondary` para una distinción visual clara como acción secundaria.