### PR TITLE
feat: Implementar página de Caja con flujo de pago

### DIFF
--- a/backend/api/v1/pedidos.php
+++ b/backend/api/v1/pedidos.php
@@ -68,7 +68,13 @@ switch ($request_method) {
 }
 
 function handleGetAllOrders($order) {
-    $stmt = $order->readAll();
+    if (!empty($_GET["estado"])) {
+        $status = htmlspecialchars(strip_tags($_GET["estado"]));
+        $stmt = $order->readByStatus($status);
+    } else {
+        $stmt = $order->readAll();
+    }
+
     $num = $stmt->rowCount();
 
     if ($num > 0) {

--- a/backend/database.sql
+++ b/backend/database.sql
@@ -20,7 +20,7 @@ CREATE TABLE usuarios ( id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(50) 
 CREATE TABLE mesas ( id INT AUTO_INCREMENT PRIMARY KEY, numero_mesa VARCHAR(10) NOT NULL, capacidad INT NOT NULL DEFAULT 4, estado ENUM('disponible', 'ocupada', 'reservada', 'mantenimiento') NOT NULL DEFAULT 'disponible' );
 CREATE TABLE categorias_producto ( id INT AUTO_INCREMENT PRIMARY KEY, nombre VARCHAR(100) NOT NULL, descripcion TEXT );
 CREATE TABLE productos ( id INT AUTO_INCREMENT PRIMARY KEY, nombre VARCHAR(100) NOT NULL, descripcion TEXT, precio DECIMAL(10, 2) NOT NULL, id_categoria INT, imagen_url VARCHAR(255), disponible BOOLEAN DEFAULT TRUE, FOREIGN KEY (id_categoria) REFERENCES categorias_producto(id) );
-CREATE TABLE pedidos ( id INT AUTO_INCREMENT PRIMARY KEY, id_mesa INT NOT NULL, id_usuario_mozo INT NOT NULL, estado ENUM('recibido', 'en_preparacion', 'listo_para_servir', 'abierto', 'completado', 'cancelado') NOT NULL DEFAULT 'recibido', total DECIMAL(10, 2) DEFAULT 0.00, fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP, fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, FOREIGN KEY (id_mesa) REFERENCES mesas(id), FOREIGN KEY (id_usuario_mozo) REFERENCES usuarios(id) );
+CREATE TABLE pedidos ( id INT AUTO_INCREMENT PRIMARY KEY, id_mesa INT NOT NULL, id_usuario_mozo INT NOT NULL, estado ENUM('recibido', 'en_preparacion', 'listo_para_servir', 'abierto', 'completado', 'cancelado', 'pagado') NOT NULL DEFAULT 'recibido', total DECIMAL(10, 2) DEFAULT 0.00, fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP, fecha_actualizacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, FOREIGN KEY (id_mesa) REFERENCES mesas(id), FOREIGN KEY (id_usuario_mozo) REFERENCES usuarios(id) );
 CREATE TABLE detalle_pedidos ( id INT AUTO_INCREMENT PRIMARY KEY, id_pedido INT NOT NULL, id_producto INT NOT NULL, cantidad INT NOT NULL DEFAULT 1, precio_unitario DECIMAL(10, 2) NOT NULL, subtotal DECIMAL(10, 2) GENERATED ALWAYS AS (cantidad * precio_unitario) STORED, FOREIGN KEY (id_pedido) REFERENCES pedidos(id) ON DELETE CASCADE, FOREIGN KEY (id_producto) REFERENCES productos(id) );
 CREATE TABLE reservas ( id INT AUTO_INCREMENT PRIMARY KEY, id_mesa INT, nombre_cliente VARCHAR(100) NOT NULL, telefono_cliente VARCHAR(20), email_cliente VARCHAR(100), fecha_reserva DATETIME NOT NULL, cantidad_personas INT NOT NULL, estado ENUM('confirmada', 'cancelada', 'completada') NOT NULL DEFAULT 'confirmada', observaciones TEXT, FOREIGN KEY (id_mesa) REFERENCES mesas(id) );
 
@@ -160,6 +160,17 @@ BEGIN
     SELECT p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion FROM pedidos p LEFT JOIN mesas m ON p.id_mesa = m.id LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id ORDER BY p.fecha_creacion DESC;
 END$$
 
+DROP PROCEDURE IF EXISTS sp_getOrdersByStatus$$
+CREATE PROCEDURE sp_getOrdersByStatus(IN p_status VARCHAR(255))
+BEGIN
+    SELECT p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion
+    FROM pedidos p
+    LEFT JOIN mesas m ON p.id_mesa = m.id
+    LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id
+    WHERE FIND_IN_SET(p.estado, p_status)
+    ORDER BY p.fecha_creacion DESC;
+END$$
+
 DROP PROCEDURE IF EXISTS sp_getOrderDetail$$
 CREATE PROCEDURE sp_getOrderDetail(IN p_id_pedido INT)
 BEGIN
@@ -200,7 +211,7 @@ BEGIN
 END$$
 
 DROP PROCEDURE IF EXISTS sp_updateOrder$$
-CREATE PROCEDURE sp_updateOrder(IN p_id_pedido INT, IN p_id_mesa INT, IN p_id_usuario_mozo INT, IN p_estado ENUM('recibido', 'en_preparacion', 'listo_para_servir', 'abierto', 'completado', 'cancelado'), IN p_items_json JSON)
+CREATE PROCEDURE sp_updateOrder(IN p_id_pedido INT, IN p_id_mesa INT, IN p_id_usuario_mozo INT, IN p_estado ENUM('recibido', 'en_preparacion', 'listo_para_servir', 'abierto', 'completado', 'cancelado', 'pagado'), IN p_items_json JSON)
 BEGIN
     DECLARE v_total_calculado DECIMAL(10, 2) DEFAULT 0;
     DECLARE v_item JSON;

--- a/backend/models/Order.php
+++ b/backend/models/Order.php
@@ -15,6 +15,14 @@ class Order {
         return $stmt;
     }
 
+    public function readByStatus($status) {
+        $query = "CALL sp_getOrdersByStatus(:status)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':status', $status);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readOne($id) {
         // 1. Obtener la cabecera del pedido
         $query_header = "CALL sp_getOrderDetail(:id)";

--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -8,6 +8,19 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
 
 $page_title = 'Caja';
 include_once 'templates/header.php';
+include_once __DIR__ . '/config.php';
+
+function getCompletedOrders() {
+    // I will modify the API endpoint later to handle this properly
+    $api_url = API_BASE_URL . 'pedidos.php?estado=completado,pagado';
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($response, true);
+}
+
+$orders_data = getCompletedOrders();
 ?>
 
 <div class="dashboard-container">
@@ -15,8 +28,48 @@ include_once 'templates/header.php';
 
     <main class="main-content">
         <div class="container">
-            <h1>Caja</h1>
-            <p>El contenido de la página de caja irá aquí.</p>
+            <div class="page-header">
+                <h1>Pedidos Completados</h1>
+            </div>
+
+            <?php
+            if (isset($_GET['success'])) {
+                echo '<p class="success-message">' . htmlspecialchars($_GET['success']) . '</p>';
+            }
+            if (isset($_GET['error'])) {
+                echo '<p class="error-message">' . htmlspecialchars($_GET['error']) . '</p>';
+            }
+            ?>
+
+            <div class="order-cards-container">
+                <?php if (isset($orders_data['records']) && !empty($orders_data['records'])): ?>
+                    <?php foreach ($orders_data['records'] as $order): ?>
+                        <div class="order-card">
+                            <div class="card-header">
+                                <strong>Pedido #<?php echo htmlspecialchars($order['id']); ?></strong>
+                                <span class="status status-<?php echo htmlspecialchars($order['estado']); ?>">
+                                    <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $order['estado']))); ?>
+                                </span>
+                            </div>
+                            <div class="card-body">
+                                <p><strong>Mesa:</strong> <?php echo htmlspecialchars($order['numero_mesa'] ?? 'N/A'); ?></p>
+                                <p><strong>Mozo:</strong> <?php echo htmlspecialchars($order['nombre_mozo'] ?? 'N/A'); ?></p>
+                                <p><strong>Fecha:</strong> <?php echo htmlspecialchars(date("d/m/Y H:i", strtotime($order['fecha_creacion']))); ?></p>
+                                <p class="total"><strong>Total:</strong> <?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($order['total'], 2)); ?></p>
+                            </div>
+                            <div class="card-footer">
+                                <?php if ($order['estado'] == 'completado'): ?>
+                                    <a href="pedido_form.php?id=<?php echo $order['id']; ?>&view=pago" class="btn-card btn-edit">Pagar</a>
+                                <?php else: ?>
+                                    <button class="btn-card btn-edit" disabled>Pagado</button>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <p>No se encontraron pedidos completados.</p>
+                <?php endif; ?>
+            </div>
         </div>
     </main>
 </div>

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -6,9 +6,11 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
     exit();
 }
 
+$view = $_GET['view'] ?? 'edit'; // 'edit' or 'pago'
+$is_pago_view = $view === 'pago';
+
 $page_title = 'Crear Nuevo Pedido';
 include_once 'templates/header.php';
-// Asumo que estos archivos de configuración y los CRUD básicos ya existen
 include_once __DIR__ . '/config.php';
 
 function fetchFromAPI($endpoint) {
@@ -35,7 +37,7 @@ $order_data = null;
 if (isset($_GET['id'])) {
     $is_editing = true;
     $order_id = intval($_GET['id']);
-    $page_title = "Editar Pedido #$order_id";
+    $page_title = $is_pago_view ? "Pagar Pedido #$order_id" : "Editar Pedido #$order_id";
     $order_data = fetchFromAPI("pedidos.php?id=$order_id");
     if (isset($order_data['error']) || !$order_data) {
         $page_title = "Error";
@@ -44,10 +46,8 @@ if (isset($_GET['id'])) {
 }
 
 if ($is_editing && $order_data) {
-    // Al editar, queremos todas las mesas para poder mostrar la mesa actual del pedido aunque no esté disponible.
     $mesas_data = fetchFromAPI('mesas.php');
 } else {
-    // Para pedidos nuevos, solo mostrar mesas disponibles.
     $mesas_data = fetchFromAPI('mesas.php?status=available');
 }
 $mozos_data = fetchFromAPI('usuarios.php?rol=Mozo');
@@ -58,6 +58,12 @@ $mesas = isset($mesas_data['records']) ? $mesas_data['records'] : [];
 $mozos = isset($mozos_data['records']) ? $mozos_data['records'] : [];
 $productos = isset($productos_data['records']) ? $productos_data['records'] : [];
 $categorias = isset($categorias_data['records']) ? $categorias_data['records'] : [];
+
+$form_action = "pedido_handler.php" . ($is_editing ? "?id=$order_id" : "");
+if ($is_pago_view) {
+    $form_action .= ($is_editing ? "&" : "?") . "view=pago";
+}
+
 ?>
 
 <div class="dashboard-container">
@@ -103,8 +109,8 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
                             </span>
                         <?php endif; ?>
                     </div>
-                    <form id="order-form" method="POST" action="pedido_handler.php<?php if($is_editing) echo '?id=' . $order_id; ?>">
-                        <input type="hidden" name="estado" id="estado" value="<?php echo htmlspecialchars($order_data['estado'] ?? 'recibido'); ?>">
+                    <form id="order-form" method="POST" action="<?php echo $form_action; ?>">
+                        <input type="hidden" name="estado" id="estado" value="<?php echo htmlspecialchars($is_pago_view ? 'pagado' : ($order_data['estado'] ?? 'recibido')); ?>">
 
                         <div class="form-group">
                             <label for="id_mesa">Mesa</label>
@@ -119,7 +125,7 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
                                     $is_available = $mesa['estado'] == 'disponible';
                                     $is_selectable = $is_available || $is_selected;
                                 ?>
-                                    <option value="<?php echo $mesa['id']; ?>" <?php if ($is_selected) echo 'selected'; ?> <?php if (!$is_selectable) echo 'disabled'; ?>>
+                                    <option value="<?php echo $mesa['id']; ?>" <?php if ($is_selected) echo 'selected'; ?> <?php if (!$is_selectable && !$is_pago_view) echo 'disabled'; ?>>
                                         <?php echo htmlspecialchars($mesa['numero_mesa'] . ' (' . ucfirst($mesa['estado']) . ')'); ?>
                                     </option>
                                 <?php endforeach; ?>
@@ -149,7 +155,7 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
                             <span id="order-total" style="font-weight: bold;"><?php echo CURRENCY_SYMBOL; ?>0.00</span>
                         </div>
 
-                        <?php if ($is_editing): ?>
+                        <?php if ($is_editing && !$is_pago_view): ?>
                         <fieldset class="status-actions-frame">
                             <legend>Acciones Rápidas de Estado</legend>
                             <div class="btn-group">
@@ -161,8 +167,12 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
                         <?php endif; ?>
                         
                         <div class="form-actions">
-                            <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar' : 'Crear'; ?> Pedido</button>
-                            <a href="pedidos.php" class="btn btn-secondary">Volver a Lista</a>
+                            <button type="submit" class="btn" <?php if ($is_pago_view) echo 'style="background-color: #28a745; color: white;"'; ?>>
+                                <?php echo $is_pago_view ? 'Pagar' : ($is_editing ? 'Actualizar' : 'Crear') . ' Pedido'; ?>
+                            </button>
+                            <a href="<?php echo $is_pago_view ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
+                                Volver a <?php echo $is_pago_view ? 'Caja' : 'Lista'; ?>
+                            </a>
                         </div>
                     </form>
                 </div>
@@ -173,7 +183,6 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    // --- VARIABLES Y CONSTANTES ---
     const productList = document.getElementById('product-list');
     const orderDetailsContainer = document.getElementById('order-details');
     const orderTotalElement = document.getElementById('order-total');
@@ -184,12 +193,11 @@ document.addEventListener('DOMContentLoaded', function() {
     const currencySymbol = '<?php echo CURRENCY_SYMBOL; ?>';
     const apiBaseUrl = '<?php echo API_BASE_URL; ?>';
     const isEditing = <?php echo json_encode($is_editing); ?>;
+    const isPagoView = <?php echo json_encode($is_pago_view); ?>;
     const initialOrderData = <?php echo json_encode($is_editing ? $order_data : null); ?>;
     const mesas = <?php echo json_encode($mesas); ?>;
 
     let currentOrder = {};
-
-    // --- FUNCIONES ---
 
     function renderOrderItems() {
         const tableBody = document.querySelector('#order-items-table tbody');
@@ -202,9 +210,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const item = currentOrder[productId];
             const subtotal = item.precio * item.cantidad;
             total += subtotal;
-            // Render para tabla (desktop)
             tableBody.innerHTML += `<tr><td>${item.nombre}</td><td><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></td><td>${currencySymbol}${item.precio.toFixed(2)}</td><td>${currencySymbol}${subtotal.toFixed(2)}</td><td><button type="button" class="btn-delete delete-item" data-id="${item.id}">X</button></td></tr>`;
-            // Render para tarjetas (mobile)
             cardsContainer.innerHTML += `<div class="order-item-card"><div class="card-item-header">${item.nombre}</div><div class="card-item-body"><div class="card-item-row"><span>Precio:</span><span>${currencySymbol}${item.precio.toFixed(2)}</span></div><div class="card-item-row"><span>Cantidad:</span><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></div><div class="card-item-row"><span>Subtotal:</span><strong>${currencySymbol}${subtotal.toFixed(2)}</strong></div></div><div class="card-item-footer"><button type="button" class="btn-delete delete-item" data-id="${item.id}">Eliminar</button></div></div>`;
         }
         orderTotalElement.textContent = `${currencySymbol}${total.toFixed(2)}`;
@@ -244,10 +250,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // --- INICIALIZACIÓN Y EVENT LISTENERS ---
-
-    // Alerta si no hay mesas disponibles al crear un nuevo pedido
-    if (!isEditing && mesas.length === 0) {
+    if (!isEditing && mesas.length === 0 && !isPagoView) {
         showAlert('No hay mesas disponibles', 'Todas las mesas están ocupadas. Por favor, libere una mesa antes de crear un nuevo pedido.');
         const formContainer = document.getElementById('order-form-container');
         if (formContainer) {
@@ -256,7 +259,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    // Cargar items del pedido si estamos editando
     if (isEditing && initialOrderData && initialOrderData.items) {
         initialOrderData.items.forEach(item => {
             currentOrder[item.id_producto] = {
@@ -269,7 +271,6 @@ document.addEventListener('DOMContentLoaded', function() {
         renderOrderItems();
     }
 
-    // Listener para añadir productos al pedido
     productList.addEventListener('click', function(e) {
         const productItem = e.target.closest('.product-item');
         if (!productItem) return;
@@ -288,13 +289,13 @@ document.addEventListener('DOMContentLoaded', function() {
         renderOrderItems();
     });
 
-    // Listener para acciones en la grilla de detalles (cambiar cantidad, eliminar)
     orderDetailsContainer.addEventListener('click', function(e) {
         if (e.target.classList.contains('delete-item')) {
             delete currentOrder[e.target.dataset.id];
             renderOrderItems();
         }
     });
+
     orderDetailsContainer.addEventListener('input', function(e) {
         if (e.target.classList.contains('item-quantity')) {
             const newQuantity = parseInt(e.target.value, 10);
@@ -308,7 +309,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    // Listener para los botones de cambio de estado
     document.querySelectorAll('.status-btn').forEach(button => {
         button.addEventListener('click', function() {
             estadoInput.value = this.dataset.status;
@@ -316,7 +316,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
-    // Listener para el envío del formulario
     orderForm.addEventListener('submit', function(e) {
         const itemsInput = document.createElement('input');
         itemsInput.type = 'hidden';
@@ -325,7 +324,6 @@ document.addEventListener('DOMContentLoaded', function() {
         this.appendChild(itemsInput);
     });
 
-    // Listener para el filtro de categorías
     categoryFilters.addEventListener('click', function(e) {
         const targetButton = e.target.closest('button.btn-category');
         if (!targetButton) return;

--- a/frontend_web/pedido_handler.php
+++ b/frontend_web/pedido_handler.php
@@ -12,6 +12,8 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 $is_editing = isset($_GET['id']);
 $order_id = $is_editing ? intval($_GET['id']) : null;
+$view = $_GET['view'] ?? 'edit';
+$is_pago_view = $view === 'pago';
 
 // Recoger los datos del formulario
 $id_mesa = $_POST['id_mesa'] ?? null;
@@ -20,8 +22,14 @@ $estado = $_POST['estado'] ?? 'recibido';
 $items_json = $_POST['items'] ?? '[]';
 $items = json_decode($items_json);
 
+$redirect_url = $is_pago_view ? 'caja.php' : 'pedidos.php';
+
 if (!$id_mesa || !$id_usuario_mozo || empty($items)) {
-    header('Location: pedido_form.php' . ($is_editing ? "?id=$order_id" : "") . '&error=Faltan+datos+esenciales.');
+    $error_param = $is_editing ? "?id=$order_id" : "";
+    if ($is_pago_view) {
+        $error_param .= ($is_editing ? "&" : "?") . "view=pago";
+    }
+    header("Location: pedido_form.php$error_param&error=Faltan+datos+esenciales.");
     exit();
 }
 
@@ -60,6 +68,6 @@ $response_data = json_decode($response, true);
 $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
 $message = urlencode($response_data['message'] ?? 'Ocurrió un error inesperado.');
 
-header("Location: pedidos.php?$message_key=$message");
+header("Location: $redirect_url?$message_key=$message");
 exit();
 ?>


### PR DESCRIPTION
Esta entrega introduce la funcionalidad completa de la página de 'Caja', diseñada para gestionar el proceso de pago de los pedidos.

Cambios clave:
- Se crea la página `frontend_web/caja.php` que muestra los pedidos en estado 'completado' y 'pagado'.
- Se añade un botón 'Pagar' a los pedidos completados, que redirige a una vista de pago.
- Se reutiliza y adapta `frontend_web/pedido_form.php` para la vista de pago, controlando la interfaz mediante un parámetro `view=pago` en la URL.
- En la vista de pago, se ocultan las acciones de cambio de estado y se personaliza el botón de envío para que sea 'Pagar' con un estilo distintivo.
- Se actualiza `frontend_web/pedido_handler.php` para procesar la actualización al estado 'pagado' y redirigir de vuelta a la página de Caja.
- Se modifica el endpoint de la API de pedidos (`backend/api/v1/pedidos.php`) para aceptar un listado de estados separados por coma.
- Se actualiza el procedimiento almacenado `sp_getOrdersByStatus` en `backend/database.sql` para utilizar `FIND_IN_SET`, permitiendo el filtrado por múltiples estados.
- Se añade el estado 'pagado' a la columna `estado` de la tabla `pedidos` y al procedimiento `sp_updateOrder`.
- Se elimina el archivo `backend/caja_queries.sql` por ser redundante.