### PR TITLE
feat: Implementar página de Caja y columna 'Tipo de Mesa'

### DIFF
--- a/backend/api/v1/pedidos.php
+++ b/backend/api/v1/pedidos.php
@@ -68,6 +68,10 @@ switch ($request_method) {
 }
 
 function handleGetAllOrders($order) {
+    // El parámetro 'estado' puede ser una cadena de estados separados por comas (ej. "completado,pagado").
+    // El procedimiento almacenado sp_getOrdersByStatus utiliza FIND_IN_SET de MySQL,
+    // que está diseñado para buscar una cadena dentro de un conjunto de cadenas separadas por comas.
+    // Por lo tanto, no es necesario explotar la cadena en un array en PHP.
     if (!empty($_GET["estado"])) {
         $status = htmlspecialchars(strip_tags($_GET["estado"]));
         $stmt = $order->readByStatus($status);

--- a/backend/models/Table.php
+++ b/backend/models/Table.php
@@ -30,25 +30,27 @@ class Table {
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 
-    public function create($numero_mesa, $capacidad, $estado) {
-        $query = "CALL sp_createTable(:numero_mesa, :capacidad, :estado)";
+    public function create($numero_mesa, $capacidad, $estado, $es_libre) {
+        $query = "CALL sp_createTable(:numero_mesa, :capacidad, :estado, :es_libre)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':numero_mesa', $numero_mesa);
         $stmt->bindParam(':capacidad', $capacidad);
         $stmt->bindParam(':estado', $estado);
+        $stmt->bindParam(':es_libre', $es_libre, PDO::PARAM_BOOL);
         if ($stmt->execute()) {
             return $stmt;
         }
         return false;
     }
 
-    public function update($id, $numero_mesa, $capacidad, $estado) {
-        $query = "CALL sp_updateTable(:id, :numero_mesa, :capacidad, :estado)";
+    public function update($id, $numero_mesa, $capacidad, $estado, $es_libre) {
+        $query = "CALL sp_updateTable(:id, :numero_mesa, :capacidad, :estado, :es_libre)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':id', $id);
         $stmt->bindParam(':numero_mesa', $numero_mesa);
         $stmt->bindParam(':capacidad', $capacidad);
         $stmt->bindParam(':estado', $estado);
+        $stmt->bindParam(':es_libre', $es_libre, PDO::PARAM_BOOL);
         return $stmt->execute();
     }
 

--- a/backend/update_mesas_add_es_libre.sql
+++ b/backend/update_mesas_add_es_libre.sql
@@ -1,0 +1,32 @@
+-- Script para añadir la columna es_libre a la tabla mesas
+ALTER TABLE `mesas` ADD COLUMN `es_libre` BOOLEAN NOT NULL DEFAULT TRUE;
+
+DELIMITER $$
+
+-- Procedimientos para 'mesas'
+DROP PROCEDURE IF EXISTS sp_getAllTables$$
+CREATE PROCEDURE sp_getAllTables()
+BEGIN
+    SELECT id, numero_mesa, capacidad, estado, es_libre FROM mesas ORDER BY numero_mesa;
+END$$
+
+DROP PROCEDURE IF EXISTS sp_readOneTable$$
+CREATE PROCEDURE sp_readOneTable(IN p_id INT)
+BEGIN
+    SELECT id, numero_mesa, capacidad, estado, es_libre FROM mesas WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS sp_createTable$$
+CREATE PROCEDURE sp_createTable(IN p_numero_mesa VARCHAR(10), IN p_capacidad INT, IN p_estado ENUM('disponible', 'ocupada', 'reservada', 'mantenimiento'), IN p_es_libre BOOLEAN)
+BEGIN
+    INSERT INTO mesas (numero_mesa, capacidad, estado, es_libre) VALUES (p_numero_mesa, p_capacidad, p_estado, p_es_libre);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+DROP PROCEDURE IF EXISTS sp_updateTable$$
+CREATE PROCEDURE sp_updateTable(IN p_id INT, IN p_numero_mesa VARCHAR(10), IN p_capacidad INT, IN p_estado ENUM('disponible', 'ocupada', 'reservada', 'mantenimiento'), IN p_es_libre BOOLEAN)
+BEGIN
+    UPDATE mesas SET numero_mesa = p_numero_mesa, capacidad = p_capacidad, estado = p_estado, es_libre = p_es_libre WHERE id = p_id;
+END$$
+
+DELIMITER ;

--- a/frontend_web/assets/css/style.css
+++ b/frontend_web/assets/css/style.css
@@ -262,6 +262,13 @@ table th { background-color: var(--light-bg); font-weight: 600; }
 .btn-cancelado { background-color: #f8d7da; color: #842029; border: 1px solid #f5c6cb; }
 .btn-cancelado:hover { background-color: #f5c6cb; border-color: #f1b9c0; }
 
+/* Estilos para formularios deshabilitados (ej. pedido pagado) */
+.is-paid .product-list-container,
+.is-paid .order-details .form-group {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
 /* Encabezado de detalles del pedido */
 .order-details-header {
     display: flex;

--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -60,8 +60,8 @@ $orders_data = getCompletedOrders();
                             <div class="card-footer">
                                 <?php if ($order['estado'] == 'completado'): ?>
                                     <a href="pedido_form.php?id=<?php echo $order['id']; ?>&view=pago" class="btn-card btn-edit">Pagar</a>
-                                <?php else: ?>
-                                    <button class="btn-card btn-edit" disabled>Pagado</button>
+                                <?php elseif ($order['estado'] == 'pagado'): ?>
+                                    <a href="pedido_form.php?id=<?php echo $order['id']; ?>&view=pago" class="btn-card btn-view">Ver Detalle</a>
                                 <?php endif; ?>
                             </div>
                         </div>

--- a/frontend_web/mesa_form.php
+++ b/frontend_web/mesa_form.php
@@ -56,6 +56,12 @@ $estados = ['disponible', 'ocupada', 'reservada', 'mantenimiento'];
                             <?php endforeach; ?>
                         </select>
                     </div>
+                    <div class="form-group">
+                        <label for="es_libre">
+                            <input type="checkbox" id="es_libre" name="es_libre" value="1" <?php echo ($table_data['es_libre'] ?? true) ? 'checked' : ''; ?>>
+                            Mesa de Servicio Libre
+                        </label>
+                    </div>
                     <div class="form-actions">
                         <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar' : 'Crear'; ?></button>
                     </div>

--- a/frontend_web/mesa_handler.php
+++ b/frontend_web/mesa_handler.php
@@ -17,7 +17,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = [
         'numero_mesa' => $_POST['numero_mesa'],
         'capacidad' => $_POST['capacidad'],
-        'estado' => $_POST['estado']
+        'estado' => $_POST['estado'],
+        'es_libre' => isset($_POST['es_libre']) ? 1 : 0
     ];
 
     $ch = curl_init($api_url);

--- a/frontend_web/mesas.php
+++ b/frontend_web/mesas.php
@@ -38,6 +38,7 @@ $tables_data = getTables();
                             <th>Número de Mesa</th>
                             <th>Capacidad</th>
                             <th>Estado</th>
+                            <th>Tipo de Mesa</th>
                             <th>Acciones</th>
                         </tr>
                     </thead>
@@ -53,6 +54,9 @@ $tables_data = getTables();
                                             <?php echo htmlspecialchars(ucfirst($table['estado'])); ?>
                                         </span>
                                     </td>
+                                    <td>
+                                        <input type="checkbox" <?php echo ($table['es_libre'] ?? false) ? 'checked' : ''; ?> disabled>
+                                    </td>
                                     <td class="actions-cell">
                                         <a href="mesa_form.php?id=<?php echo $table['id']; ?>" class="btn btn-edit">Editar</a>
                                         <a href="mesa_delete_handler.php?id=<?php echo $table['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro?');">Eliminar</a>
@@ -60,7 +64,7 @@ $tables_data = getTables();
                                 </tr>
                             <?php endforeach; ?>
                         <?php else: ?>
-                            <tr><td colspan="5">No se encontraron mesas.</td></tr>
+                            <tr><td colspan="6">No se encontraron mesas.</td></tr>
                         <?php endif; ?>
                     </tbody>
                 </table>

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -8,6 +8,7 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
 
 $view = $_GET['view'] ?? 'edit'; // 'edit' or 'pago'
 $is_pago_view = $view === 'pago';
+$is_paid = false;
 
 $page_title = 'Crear Nuevo Pedido';
 include_once 'templates/header.php';
@@ -42,6 +43,8 @@ if (isset($_GET['id'])) {
     if (isset($order_data['error']) || !$order_data) {
         $page_title = "Error";
         $order_data = null;
+    } else {
+        $is_paid = $order_data['estado'] === 'pagado';
     }
 }
 
@@ -74,7 +77,7 @@ if ($is_pago_view) {
                 <h1><?php echo $page_title; ?></h1>
             </div>
 
-            <div id="order-form-container" class="order-grid">
+<div id="order-form-container" class="order-grid <?php if ($is_paid) echo 'is-paid'; ?>">
                 <div class="product-list-container">
                     <h3>Productos Disponibles</h3>
                     <div id="category-filters" class="category-filters">
@@ -114,7 +117,7 @@ if ($is_pago_view) {
 
                         <div class="form-group">
                             <label for="id_mesa">Mesa</label>
-                            <select id="id_mesa" name="id_mesa" required>
+                            <select id="id_mesa" name="id_mesa" required <?php if ($is_paid) echo 'disabled'; ?>>
                                 <?php
                                 if (empty($mesas) && $is_editing && $order_data) {
                                     echo "<option value=\"{$order_data['id_mesa']}\" selected>Mesa {$order_data['id_mesa']} (Actual)</option>";
@@ -133,7 +136,7 @@ if ($is_pago_view) {
                         </div>
                         <div class="form-group">
                             <label for="id_usuario_mozo">Mozo</label>
-                            <select id="id_usuario_mozo" name="id_usuario_mozo" required>
+                            <select id="id_usuario_mozo" name="id_usuario_mozo" required <?php if ($is_paid) echo 'disabled'; ?>>
                                  <?php foreach ($mozos as $mozo): ?>
                                     <option value="<?php echo $mozo['id']; ?>" <?php if($is_editing && $order_data['id_usuario_mozo'] == $mozo['id']) echo 'selected'; ?>>
                                         <?php echo htmlspecialchars($mozo['nombre_completo']); ?>
@@ -167,8 +170,8 @@ if ($is_pago_view) {
                         <?php endif; ?>
                         
                         <div class="form-actions">
-                            <button type="submit" class="btn" <?php if ($is_pago_view) echo 'style="background-color: #28a745; color: white;"'; ?>>
-                                <?php echo $is_pago_view ? 'Pagar' : ($is_editing ? 'Actualizar' : 'Crear') . ' Pedido'; ?>
+                            <button type="submit" class="btn" <?php if ($is_pago_view && !$is_paid) echo 'style="background-color: #28a745; color: white;"'; ?> <?php if ($is_paid) echo 'disabled'; ?>>
+                                <?php echo $is_paid ? 'Pagado' : ($is_pago_view ? 'Pagar' : ($is_editing ? 'Actualizar' : 'Crear') . ' Pedido'); ?>
                             </button>
                             <a href="<?php echo $is_pago_view ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
                                 Volver a <?php echo $is_pago_view ? 'Caja' : 'Lista'; ?>


### PR DESCRIPTION
Esta entrega introduce dos nuevas funcionalidades principales: la página de 'Caja' y la gestión del 'Tipo de Mesa'.

Cambios en la página de 'Caja':
- Creación de `caja.php` para listar pedidos completados y pagados.
- Adaptación de `pedido_form.php` y `pedido_handler.php` para un flujo de pago reutilizable.
- Lógica de UI mejorada para deshabilitar acciones en pedidos ya pagados.
- Creación de `update_caja_feature.sql` con los cambios de BBDD no destructivos.

Cambios en 'Tipo de Mesa':
- Creación de `update_mesas_add_es_libre.sql` para añadir la columna `es_libre` a la tabla `mesas` y los SPs correspondientes.
- Actualización del modelo `Table.php` para usar los nuevos SPs.
- Modificación de `mesas.php`, `mesa_form.php` y `mesa_handler.php` para mostrar y gestionar el nuevo campo.