### PR TITLE
feat: Filtrar mesas disponibles para nuevos pedidos

### DIFF
--- a/backend/update_mesas_available_logic.sql
+++ b/backend/update_mesas_available_logic.sql
@@ -1,0 +1,14 @@
+-- Script para actualizar la lógica de obtención de mesas disponibles
+
+DELIMITER $$
+
+-- Actualizar procedimiento para que solo devuelva mesas que no son de servicio libre
+DROP PROCEDURE IF EXISTS sp_getAvailableTables$$
+CREATE PROCEDURE sp_getAvailableTables()
+BEGIN
+    SELECT id, numero_mesa, capacidad, estado, es_libre
+    FROM mesas
+    WHERE estado = 'disponible' AND es_libre = 0;
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
Se actualiza la lógica para obtener las mesas disponibles al crear un nuevo pedido.

El procedimiento almacenado `sp_getAvailableTables` ha sido modificado para que solo devuelva las mesas que están en estado 'disponible' y que no están marcadas como 'Mesa de Servicio Libre' (`es_libre` = 0). Esto asegura que los nuevos pedidos solo se puedan asignar a mesas que no son de servicio libre.