### PR TITLE
feat: Añadir flujo de creación de pedidos desde Caja

### DIFF
--- a/backend/api/v1/mesas.php
+++ b/backend/api/v1/mesas.php
@@ -29,6 +29,10 @@ switch ($request_method) {
         if (isset($_GET['status']) && $_GET['status'] == 'available') {
             $stmt = $table->getAvailableTables();
             sendRecords($stmt);
+        } elseif (isset($_GET['es_libre'])) {
+            $es_libre_val = intval($_GET['es_libre']);
+            $stmt = $table->readByLibreStatus($es_libre_val);
+            sendRecords($stmt);
         } elseif (!empty($_GET["id"])) {
             $table_id = intval($_GET["id"]);
             $table_data = $table->readOne($table_id);

--- a/backend/models/Table.php
+++ b/backend/models/Table.php
@@ -15,6 +15,14 @@ class Table {
         return $stmt;
     }
 
+    public function readByLibreStatus($es_libre) {
+        $query = "CALL sp_getTablesByLibreStatus(:es_libre)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':es_libre', $es_libre, PDO::PARAM_BOOL);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function getAvailableTables() {
         $query = "CALL sp_getAvailableTables()";
         $stmt = $this->conn->prepare($query);

--- a/backend/update_mesas_feature.sql
+++ b/backend/update_mesas_feature.sql
@@ -52,4 +52,12 @@ BEGIN
       );
 END$$
 
+DROP PROCEDURE IF EXISTS sp_getTablesByLibreStatus$$
+CREATE PROCEDURE sp_getTablesByLibreStatus(IN p_es_libre BOOLEAN)
+BEGIN
+    SELECT id, numero_mesa, capacidad, estado, es_libre
+    FROM mesas
+    WHERE es_libre = p_es_libre;
+END$$
+
 DELIMITER ;

--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -30,6 +30,7 @@ $orders_data = getCompletedOrders();
         <div class="container">
             <div class="page-header">
                 <h1>Pedidos Completados</h1>
+                <a href="pedido_form.php?view=caja_create" class="btn">Crear Pedido Nuevo</a>
             </div>
 
             <?php

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -6,11 +6,15 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
     exit();
 }
 
-$view = $_GET['view'] ?? 'edit'; // 'edit' or 'pago'
+$view = $_GET['view'] ?? 'edit'; // 'edit', 'pago', or 'caja_create'
 $is_pago_view = $view === 'pago';
+$is_caja_create_view = $view === 'caja_create';
 $is_paid = false;
 
 $page_title = 'Crear Nuevo Pedido';
+if ($is_caja_create_view) {
+    $page_title = 'Crear Pedido de Caja';
+}
 include_once 'templates/header.php';
 include_once __DIR__ . '/config.php';
 
@@ -50,10 +54,16 @@ if (isset($_GET['id'])) {
 
 if ($is_editing && $order_data) {
     $mesas_data = fetchFromAPI('mesas.php');
-} else {
+} else if ($is_caja_create_view) {
+    // For new "Caja" orders, fetch tables where es_libre = 0 (Tipo de Mesa Libre Desactivado)
+    $mesas_data = fetchFromAPI('mesas.php?es_libre=0');
+}
+else {
     $mesas_data = fetchFromAPI('mesas.php?status=available');
 }
-$mozos_data = fetchFromAPI('usuarios.php?rol=Mozo');
+
+$rol_to_fetch = $is_caja_create_view ? 'Cajero' : 'Mozo';
+$mozos_data = fetchFromAPI("usuarios.php?rol=$rol_to_fetch");
 $productos_data = fetchFromAPI('productos.php?estado=activo');
 $categorias_data = fetchFromAPI('categorias.php');
 
@@ -65,6 +75,8 @@ $categorias = isset($categorias_data['records']) ? $categorias_data['records'] :
 $form_action = "pedido_handler.php" . ($is_editing ? "?id=$order_id" : "");
 if ($is_pago_view) {
     $form_action .= ($is_editing ? "&" : "?") . "view=pago";
+} else if ($is_caja_create_view) {
+    $form_action .= "?view=caja_create";
 }
 
 ?>
@@ -171,10 +183,20 @@ if ($is_pago_view) {
                         
                         <div class="form-actions">
                             <button type="submit" class="btn" <?php if ($is_pago_view && !$is_paid) echo 'style="background-color: #28a745; color: white;"'; ?> <?php if ($is_paid) echo 'disabled'; ?>>
-                                <?php echo $is_paid ? 'Pagado' : ($is_pago_view ? 'Pagar' : ($is_editing ? 'Actualizar' : 'Crear') . ' Pedido'); ?>
+                                <?php
+                                    if ($is_paid) {
+                                        echo 'Pagado';
+                                    } else if ($is_pago_view) {
+                                        echo 'Pagar';
+                                    } else if ($is_caja_create_view) {
+                                        echo 'Crear Pedido';
+                                    } else {
+                                        echo ($is_editing ? 'Actualizar' : 'Crear') . ' Pedido';
+                                    }
+                                ?>
                             </button>
-                            <a href="<?php echo $is_pago_view ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
-                                Volver a <?php echo $is_pago_view ? 'Caja' : 'Lista'; ?>
+                            <a href="<?php echo ($is_pago_view || $is_caja_create_view) ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
+                                Volver a <?php echo ($is_pago_view || $is_caja_create_view) ? 'Caja' : 'Lista'; ?>
                             </a>
                         </div>
                     </form>

--- a/frontend_web/pedido_handler.php
+++ b/frontend_web/pedido_handler.php
@@ -14,6 +14,7 @@ $is_editing = isset($_GET['id']);
 $order_id = $is_editing ? intval($_GET['id']) : null;
 $view = $_GET['view'] ?? 'edit';
 $is_pago_view = $view === 'pago';
+$is_caja_create_view = $view === 'caja_create';
 
 // Recoger los datos del formulario
 $id_mesa = $_POST['id_mesa'] ?? null;
@@ -22,12 +23,18 @@ $estado = $_POST['estado'] ?? 'recibido';
 $items_json = $_POST['items'] ?? '[]';
 $items = json_decode($items_json);
 
-$redirect_url = $is_pago_view ? 'caja.php' : 'pedidos.php';
+if ($is_pago_view || $is_caja_create_view) {
+    $redirect_url = 'caja.php';
+} else {
+    $redirect_url = 'pedidos.php';
+}
 
 if (!$id_mesa || !$id_usuario_mozo || empty($items)) {
     $error_param = $is_editing ? "?id=$order_id" : "";
     if ($is_pago_view) {
         $error_param .= ($is_editing ? "&" : "?") . "view=pago";
+    } else if ($is_caja_create_view) {
+        $error_param = "?view=caja_create";
     }
     header("Location: pedido_form.php$error_param&error=Faltan+datos+esenciales.");
     exit();


### PR DESCRIPTION
Se implementa la capacidad de crear un nuevo pedido desde la página de 'Caja', dirigido a ser gestionado por cajeros y para mesas que no son de servicio libre.

Cambios clave:
- Se añade el botón 'Crear Pedido Nuevo' en `caja.php`.
- Se modifica `pedido_form.php` para manejar una nueva vista `caja_create`, alterando dinámicamente el contenido de los combos de 'Mozo' y 'Mesa'.
- Se actualiza `pedido_handler.php` para redirigir a `caja.php` después de la creación del pedido en este nuevo flujo.
- Se añade el endpoint `mesas.php?es_libre=0` a la API.
- Se añade el método `readByLibreStatus` al modelo `Table.php`.
- Se añade el procedimiento `sp_getTablesByLibreStatus` al script `update_mesas_feature.sql` y se consolidan los scripts.