### PR TITLE
feat: Implement CRUDs for identity and sale document types

### DIFF
--- a/backend/api/v1/tipo_documento_identidad.php
+++ b/backend/api/v1/tipo_documento_identidad.php
@@ -1,0 +1,95 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../models/IdentityDocumentType.php';
+
+$identityDocumentType = new IdentityDocumentType();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            $type_id = intval($_GET["id"]);
+            $type_data = $identityDocumentType->readOne($type_id);
+            if ($type_data) {
+                http_response_code(200);
+                echo json_encode($type_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Tipo de documento no encontrado."]);
+            }
+        } else {
+            $stmt = $identityDocumentType->readAll();
+            $num = $stmt->rowCount();
+            if ($num > 0) {
+                $types_arr = ["records" => []];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    $row['estado'] = (bool)$row['estado'];
+                    array_push($types_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($types_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode(["records" => []]);
+            }
+        }
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->codigo) && !empty($data->nombre)) {
+            $stmt = $identityDocumentType->create($data->codigo, $data->nombre, $data->descripcion ?? '');
+            if ($stmt) {
+                $new_type = $stmt->fetch(PDO::FETCH_ASSOC);
+                http_response_code(201);
+                echo json_encode(["message" => "Tipo de documento creado.", "id" => $new_type['id']]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear el tipo de documento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        $type_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+        if ($type_id && !empty($data->codigo) && !empty($data->nombre)) {
+            $estado = isset($data->estado) ? (bool)$data->estado : true;
+            if ($identityDocumentType->update($type_id, $data->codigo, $data->nombre, $data->descripcion ?? '', $estado)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Tipo de documento actualizado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar el tipo de documento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+    case 'DELETE':
+        $type_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+        if ($type_id) {
+            if ($identityDocumentType->delete($type_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Tipo de documento eliminado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar el tipo de documento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+?>

--- a/backend/api/v1/tipos_documentos.php
+++ b/backend/api/v1/tipos_documentos.php
@@ -1,0 +1,95 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../models/SaleDocumentType.php';
+
+$saleDocumentType = new SaleDocumentType();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            $type_id = intval($_GET["id"]);
+            $type_data = $saleDocumentType->readOne($type_id);
+            if ($type_data) {
+                http_response_code(200);
+                echo json_encode($type_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Tipo de documento no encontrado."]);
+            }
+        } else {
+            $stmt = $saleDocumentType->readAll();
+            $num = $stmt->rowCount();
+            if ($num > 0) {
+                $types_arr = ["records" => []];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    $row['estado'] = (bool)$row['estado'];
+                    array_push($types_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($types_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode(["records" => []]);
+            }
+        }
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->codigo) && !empty($data->nombre)) {
+            $stmt = $saleDocumentType->create($data->codigo, $data->nombre, $data->descripcion ?? '');
+            if ($stmt) {
+                $new_type = $stmt->fetch(PDO::FETCH_ASSOC);
+                http_response_code(201);
+                echo json_encode(["message" => "Tipo de documento creado.", "id" => $new_type['id']]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear el tipo de documento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        $type_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+        if ($type_id && !empty($data->codigo) && !empty($data->nombre)) {
+            $estado = isset($data->estado) ? (bool)$data->estado : true;
+            if ($saleDocumentType->update($type_id, $data->codigo, $data->nombre, $data->descripcion ?? '', $estado)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Tipo de documento actualizado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar el tipo de documento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+    case 'DELETE':
+        $type_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+        if ($type_id) {
+            if ($saleDocumentType->delete($type_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Tipo de documento eliminado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar el tipo de documento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+?>

--- a/backend/migrate.php
+++ b/backend/migrate.php
@@ -1,0 +1,55 @@
+<?php
+// Simple migration script
+require_once __DIR__ . '/config/database.php';
+
+try {
+    $pdo = new PDO("mysql:host=" . DB_HOST . ";dbname=" . DB_NAME, DB_USER, DB_PASS);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    echo "Database connection successful.\n";
+} catch (PDOException $e) {
+    die("Database connection failed: " . $e->getMessage() . "\n");
+}
+
+function run_sql_file($pdo, $filepath) {
+    echo "Running SQL file: " . basename($filepath) . "...\n";
+    try {
+        $sql = file_get_contents($filepath);
+        // PDO does not support multiple queries with exec or query, so we need to split them.
+        $commands = preg_split('/;(?=\s*[^;]*$)/', $sql);
+        foreach ($commands as $command) {
+            if (trim($command) === '') continue;
+            $stmt = $pdo->prepare($command);
+            $stmt->execute();
+        }
+        echo "SQL file " . basename($filepath) . " applied successfully.\n";
+    } catch (PDOException $e) {
+        echo "Error applying SQL file " . basename($filepath) . ": " . $e->getMessage() . "\n";
+        // exit(1); // Exit on error
+    }
+}
+
+// Run the main database schema first
+$databaseSqlFile = __DIR__ . '/database.sql';
+if (file_exists($databaseSqlFile)) {
+    run_sql_file($pdo, $databaseSqlFile);
+} else {
+    echo "Main database.sql file not found. Skipping.\n";
+}
+
+
+$migrationsDir = __DIR__ . '/migrations';
+$files = glob($migrationsDir . '/*.sql');
+
+if (empty($files)) {
+    echo "No migration files found.\n";
+} else {
+    // Sort files to run them in order
+    sort($files);
+
+    foreach ($files as $file) {
+        run_sql_file($pdo, $file);
+    }
+}
+
+echo "All migrations completed.\n";
+?>

--- a/backend/migrations/20250921_add_identity_docs.sql
+++ b/backend/migrations/20250921_add_identity_docs.sql
@@ -1,0 +1,82 @@
+-- Migration to add identity document types table and procedures
+
+-- -----------------------------------------------------
+-- Table `tipo_documento_identidad`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tipo_documento_identidad` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `codigo` VARCHAR(2) NOT NULL UNIQUE,
+  `nombre` VARCHAR(100) NOT NULL,
+  `descripcion` TEXT,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------------------------------------
+-- Initial Data for `tipo_documento_identidad`
+-- -----------------------------------------------------
+INSERT INTO `tipo_documento_identidad` (`codigo`, `nombre`, `descripcion`) VALUES
+('1', 'Documento Nacional de Identidad', 'DNI'),
+('4', 'Carnet de Extranjería', 'Carnet de Extranjería'),
+('6', 'Registro Único de Contribuyentes', 'RUC'),
+('7', 'Pasaporte', 'Pasaporte'),
+('A', 'Cédula Diplomática de Identidad', 'Cédula Diplomática de Identidad'),
+('0', 'Otros', 'Otros tipos de documentos');
+
+-- -----------------------------------------------------
+-- Stored Procedures for `tipo_documento_identidad`
+-- -----------------------------------------------------
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_getAllIdentityDocumentTypes`$$
+CREATE PROCEDURE `sp_getAllIdentityDocumentTypes`()
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado
+    FROM `tipo_documento_identidad`
+    ORDER BY nombre;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_getOneIdentityDocumentType`$$
+CREATE PROCEDURE `sp_getOneIdentityDocumentType`(IN p_id INT)
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado
+    FROM `tipo_documento_identidad`
+    WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_createIdentityDocumentType`$$
+CREATE PROCEDURE `sp_createIdentityDocumentType`(
+    IN p_codigo VARCHAR(2),
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT
+)
+BEGIN
+    INSERT INTO `tipo_documento_identidad` (codigo, nombre, descripcion)
+    VALUES (p_codigo, p_nombre, p_descripcion);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_updateIdentityDocumentType`$$
+CREATE PROCEDURE `sp_updateIdentityDocumentType`(
+    IN p_id INT,
+    IN p_codigo VARCHAR(2),
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE `tipo_documento_identidad`
+    SET
+        codigo = p_codigo,
+        nombre = p_nombre,
+        descripcion = p_descripcion,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_deleteIdentityDocumentType`$$
+CREATE PROCEDURE `sp_deleteIdentityDocumentType`(IN p_id INT)
+BEGIN
+    DELETE FROM `tipo_documento_identidad` WHERE id = p_id;
+END$$
+
+DELIMITER ;

--- a/backend/migrations/20250921_add_sale_document_types.sql
+++ b/backend/migrations/20250921_add_sale_document_types.sql
@@ -1,0 +1,82 @@
+-- Migration to add sale document types table and procedures
+
+-- -----------------------------------------------------
+-- Table `tipo_documento_venta`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tipo_documento_venta` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `codigo` VARCHAR(2) NOT NULL UNIQUE,
+  `nombre` VARCHAR(100) NOT NULL,
+  `descripcion` TEXT,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------------------------------------
+-- Initial Data for `tipo_documento_venta`
+-- -----------------------------------------------------
+INSERT INTO `tipo_documento_venta` (`codigo`, `nombre`, `descripcion`) VALUES
+('01', 'Factura', 'Factura Electrónica'),
+('03', 'Boleta de Venta', 'Boleta de Venta Electrónica'),
+('07', 'Nota de Crédito', 'Nota de Crédito Electrónica'),
+('08', 'Nota de Débito', 'Nota de Débito Electrónica'),
+('12', 'Ticket de Máquina Registradora', 'Ticket o cinta emitido por máquina registradora'),
+('00', 'Otros', 'Otros tipos de comprobantes de pago');
+
+-- -----------------------------------------------------
+-- Stored Procedures for `tipo_documento_venta`
+-- -----------------------------------------------------
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_getAllSaleDocumentTypes`$$
+CREATE PROCEDURE `sp_getAllSaleDocumentTypes`()
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado
+    FROM `tipo_documento_venta`
+    ORDER BY nombre;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_getOneSaleDocumentType`$$
+CREATE PROCEDURE `sp_getOneSaleDocumentType`(IN p_id INT)
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado
+    FROM `tipo_documento_venta`
+    WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_createSaleDocumentType`$$
+CREATE PROCEDURE `sp_createSaleDocumentType`(
+    IN p_codigo VARCHAR(2),
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT
+)
+BEGIN
+    INSERT INTO `tipo_documento_venta` (codigo, nombre, descripcion)
+    VALUES (p_codigo, p_nombre, p_descripcion);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_updateSaleDocumentType`$$
+CREATE PROCEDURE `sp_updateSaleDocumentType`(
+    IN p_id INT,
+    IN p_codigo VARCHAR(2),
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE `tipo_documento_venta`
+    SET
+        codigo = p_codigo,
+        nombre = p_nombre,
+        descripcion = p_descripcion,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_deleteSaleDocumentType`$$
+CREATE PROCEDURE `sp_deleteSaleDocumentType`(IN p_id INT)
+BEGIN
+    DELETE FROM `tipo_documento_venta` WHERE id = p_id;
+END$$
+
+DELIMITER ;

--- a/backend/models/IdentityDocumentType.php
+++ b/backend/models/IdentityDocumentType.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class IdentityDocumentType {
+    private $conn;
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    public function readAll() {
+        $query = "CALL sp_getAllIdentityDocumentTypes()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    public function readOne($id) {
+        $query = "CALL sp_getOneIdentityDocumentType(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($codigo, $nombre, $descripcion) {
+        $query = "CALL sp_createIdentityDocumentType(:codigo, :nombre, :descripcion)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':codigo', $codigo);
+        $stmt->bindParam(':nombre', $nombre);
+        $stmt->bindParam(':descripcion', $descripcion);
+        if ($stmt->execute()) {
+            return $stmt;
+        }
+        return false;
+    }
+
+    public function update($id, $codigo, $nombre, $descripcion, $estado) {
+        $query = "CALL sp_updateIdentityDocumentType(:id, :codigo, :nombre, :descripcion, :estado)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':codigo', $codigo);
+        $stmt->bindParam(':nombre', $nombre);
+        $stmt->bindParam(':descripcion', $descripcion);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+        return $stmt->execute();
+    }
+
+    public function delete($id) {
+        $query = "CALL sp_deleteIdentityDocumentType(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        return $stmt->execute();
+    }
+}
+?>

--- a/backend/models/SaleDocumentType.php
+++ b/backend/models/SaleDocumentType.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class SaleDocumentType {
+    private $conn;
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    public function readAll() {
+        $query = "CALL sp_getAllSaleDocumentTypes()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    public function readOne($id) {
+        $query = "CALL sp_getOneSaleDocumentType(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($codigo, $nombre, $descripcion) {
+        $query = "CALL sp_createSaleDocumentType(:codigo, :nombre, :descripcion)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':codigo', $codigo);
+        $stmt->bindParam(':nombre', $nombre);
+        $stmt->bindParam(':descripcion', $descripcion);
+        if ($stmt->execute()) {
+            return $stmt;
+        }
+        return false;
+    }
+
+    public function update($id, $codigo, $nombre, $descripcion, $estado) {
+        $query = "CALL sp_updateSaleDocumentType(:id, :codigo, :nombre, :descripcion, :estado)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':codigo', $codigo);
+        $stmt->bindParam(':nombre', $nombre);
+        $stmt->bindParam(':descripcion', $descripcion);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+        return $stmt->execute();
+    }
+
+    public function delete($id) {
+        $query = "CALL sp_deleteSaleDocumentType(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        return $stmt->execute();
+    }
+}
+?>

--- a/frontend_web/tipo_documento_identidad.php
+++ b/frontend_web/tipo_documento_identidad.php
@@ -1,22 +1,69 @@
 <?php
 session_start();
-
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
-    header('Location: index.php?error=Por+favor+inicie+sesión');
+    header('Location: index.php');
     exit();
 }
 
 $page_title = 'Tipos de Documento de Identidad';
 include_once 'templates/header.php';
+
+function getIdentityDocumentTypes() {
+    require_once 'config.php';
+    $api_url = API_BASE_URL . 'tipo_documento_identidad.php';
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($response, true);
+}
+
+$types_data = getIdentityDocumentTypes();
 ?>
 
 <div class="dashboard-container">
     <?php include_once 'templates/sidebar.php'; ?>
-
     <main class="main-content">
         <div class="container">
-            <h1>Tipos de Documento de Identidad</h1>
-            <p>El contenido de la página de tipos de documento de identidad irá aquí.</p>
+            <div class="page-header">
+                <h1>Catálogo de Tipos de Documento de Identidad</h1>
+                <a href="tipo_documento_identidad_form.php" class="btn">Crear Tipo de Documento</a>
+            </div>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Código</th>
+                            <th>Nombre</th>
+                            <th>Descripción</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (isset($types_data['records']) && !empty($types_data['records'])): ?>
+                            <?php foreach ($types_data['records'] as $type): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($type['codigo']); ?></td>
+                                    <td><?php echo htmlspecialchars($type['nombre']); ?></td>
+                                    <td><?php echo htmlspecialchars($type['descripcion']); ?></td>
+                                    <td>
+                                        <span class="status <?php echo $type['estado'] ? 'status-active' : 'status-inactive'; ?>">
+                                            <?php echo $type['estado'] ? 'Activo' : 'Inactivo'; ?>
+                                        </span>
+                                    </td>
+                                    <td class="actions-cell">
+                                        <a href="tipo_documento_identidad_form.php?id=<?php echo $type['id']; ?>" class="btn btn-edit">Editar</a>
+                                        <a href="tipo_documento_identidad_delete_handler.php?id=<?php echo $type['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro?');">Eliminar</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr><td colspan="5">No se encontraron tipos de documento.</td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </main>
 </div>

--- a/frontend_web/tipo_documento_identidad_delete_handler.php
+++ b/frontend_web/tipo_documento_identidad_delete_handler.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    require_once 'config.php';
+    $type_id = intval($_GET['id']);
+    $api_url = API_BASE_URL . 'tipo_documento_identidad.php?id=' . $type_id;
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error al eliminar.');
+
+    header("Location: tipo_documento_identidad.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: tipo_documento_identidad.php');
+    exit();
+}
+?>

--- a/frontend_web/tipo_documento_identidad_form.php
+++ b/frontend_web/tipo_documento_identidad_form.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+$page_title = 'Crear Tipo de Documento';
+$type_data = ['id' => '', 'codigo' => '', 'nombre' => '', 'descripcion' => '', 'estado' => 1];
+$is_editing = false;
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $type_id = intval($_GET['id']);
+    $page_title = 'Editar Tipo de Documento';
+
+    require_once 'config.php';
+    $api_url = API_BASE_URL . "tipo_documento_identidad.php?id=$type_id";
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $type_data = json_decode($response, true);
+    }
+}
+
+include_once 'templates/header.php';
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+                <a href="tipo_documento_identidad.php" class="btn btn-secondary">Volver</a>
+            </div>
+            <div class="form-container">
+                <form action="tipo_documento_identidad_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($type_data['id']); ?>">
+                    <div class="form-group">
+                        <label for="codigo">Código SUNAT</label>
+                        <input type="text" id="codigo" name="codigo" value="<?php echo htmlspecialchars($type_data['codigo']); ?>" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="nombre">Nombre</label>
+                        <input type="text" id="nombre" name="nombre" value="<?php echo htmlspecialchars($type_data['nombre']); ?>" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="descripcion">Descripción</label>
+                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($type_data['descripcion']); ?></textarea>
+                    </div>
+                    <?php if ($is_editing): ?>
+                    <div class="form-group">
+                        <label for="estado">Estado</label>
+                        <select id="estado" name="estado">
+                            <option value="1" <?php echo ($type_data['estado'] == 1) ? 'selected' : ''; ?>>Activo</option>
+                            <option value="0" <?php echo ($type_data['estado'] == 0) ? 'selected' : ''; ?>>Inactivo</option>
+                        </select>
+                    </div>
+                    <?php endif; ?>
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar' : 'Crear'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>

--- a/frontend_web/tipo_documento_identidad_handler.php
+++ b/frontend_web/tipo_documento_identidad_handler.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once 'config.php';
+    $is_editing = !empty($_POST['id']);
+    $api_url = API_BASE_URL . 'tipo_documento_identidad.php';
+    if ($is_editing) {
+        $api_url .= '?id=' . intval($_POST['id']);
+    }
+
+    $data = [
+        'codigo' => $_POST['codigo'],
+        'nombre' => $_POST['nombre'],
+        'descripcion' => $_POST['descripcion']
+    ];
+
+    if ($is_editing) {
+        $data['estado'] = isset($_POST['estado']) ? (int)$_POST['estado'] : 0;
+    }
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $is_editing ? 'PUT' : 'POST');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error.');
+
+    header("Location: tipo_documento_identidad.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: tipo_documento_identidad.php');
+    exit();
+}
+?>

--- a/frontend_web/tipos_documentos.php
+++ b/frontend_web/tipos_documentos.php
@@ -1,22 +1,69 @@
 <?php
 session_start();
-
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
-    header('Location: index.php?error=Por+favor+inicie+sesión');
+    header('Location: index.php');
     exit();
 }
 
-$page_title = 'Tipos de Documentos';
+$page_title = 'Tipos de Documentos de Venta';
 include_once 'templates/header.php';
+
+function getSaleDocumentTypes() {
+    require_once 'config.php';
+    $api_url = API_BASE_URL . 'tipos_documentos.php';
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($response, true);
+}
+
+$types_data = getSaleDocumentTypes();
 ?>
 
 <div class="dashboard-container">
     <?php include_once 'templates/sidebar.php'; ?>
-
     <main class="main-content">
         <div class="container">
-            <h1>Tipos de Documentos</h1>
-            <p>El contenido de la página de tipos de documentos irá aquí.</p>
+            <div class="page-header">
+                <h1>Catálogo de Tipos de Documentos de Venta</h1>
+                <a href="tipos_documentos_form.php" class="btn">Crear Tipo de Documento</a>
+            </div>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Código</th>
+                            <th>Nombre</th>
+                            <th>Descripción</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (isset($types_data['records']) && !empty($types_data['records'])): ?>
+                            <?php foreach ($types_data['records'] as $type): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($type['codigo']); ?></td>
+                                    <td><?php echo htmlspecialchars($type['nombre']); ?></td>
+                                    <td><?php echo htmlspecialchars($type['descripcion']); ?></td>
+                                    <td>
+                                        <span class="status <?php echo $type['estado'] ? 'status-active' : 'status-inactive'; ?>">
+                                            <?php echo $type['estado'] ? 'Activo' : 'Inactivo'; ?>
+                                        </span>
+                                    </td>
+                                    <td class="actions-cell">
+                                        <a href="tipos_documentos_form.php?id=<?php echo $type['id']; ?>" class="btn btn-edit">Editar</a>
+                                        <a href="tipos_documentos_delete_handler.php?id=<?php echo $type['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro?');">Eliminar</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr><td colspan="5">No se encontraron tipos de documento.</td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </main>
 </div>

--- a/frontend_web/tipos_documentos_delete_handler.php
+++ b/frontend_web/tipos_documentos_delete_handler.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    require_once 'config.php';
+    $type_id = intval($_GET['id']);
+    $api_url = API_BASE_URL . 'tipos_documentos.php?id=' . $type_id;
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error al eliminar.');
+
+    header("Location: tipos_documentos.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: tipos_documentos.php');
+    exit();
+}
+?>

--- a/frontend_web/tipos_documentos_form.php
+++ b/frontend_web/tipos_documentos_form.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+$page_title = 'Crear Tipo de Documento de Venta';
+$type_data = ['id' => '', 'codigo' => '', 'nombre' => '', 'descripcion' => '', 'estado' => 1];
+$is_editing = false;
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $type_id = intval($_GET['id']);
+    $page_title = 'Editar Tipo de Documento de Venta';
+
+    require_once 'config.php';
+    $api_url = API_BASE_URL . "tipos_documentos.php?id=$type_id";
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $type_data = json_decode($response, true);
+    }
+}
+
+include_once 'templates/header.php';
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+                <a href="tipos_documentos.php" class="btn btn-secondary">Volver</a>
+            </div>
+            <div class="form-container">
+                <form action="tipos_documentos_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($type_data['id']); ?>">
+                    <div class="form-group">
+                        <label for="codigo">Código SUNAT</label>
+                        <input type="text" id="codigo" name="codigo" value="<?php echo htmlspecialchars($type_data['codigo']); ?>" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="nombre">Nombre</label>
+                        <input type="text" id="nombre" name="nombre" value="<?php echo htmlspecialchars($type_data['nombre']); ?>" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="descripcion">Descripción</label>
+                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($type_data['descripcion']); ?></textarea>
+                    </div>
+                    <?php if ($is_editing): ?>
+                    <div class="form-group">
+                        <label for="estado">Estado</label>
+                        <select id="estado" name="estado">
+                            <option value="1" <?php echo ($type_data['estado'] == 1) ? 'selected' : ''; ?>>Activo</option>
+                            <option value="0" <?php echo ($type_data['estado'] == 0) ? 'selected' : ''; ?>>Inactivo</option>
+                        </select>
+                    </div>
+                    <?php endif; ?>
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar' : 'Crear'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>

--- a/frontend_web/tipos_documentos_handler.php
+++ b/frontend_web/tipos_documentos_handler.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once 'config.php';
+    $is_editing = !empty($_POST['id']);
+    $api_url = API_BASE_URL . 'tipos_documentos.php';
+    if ($is_editing) {
+        $api_url .= '?id=' . intval($_POST['id']);
+    }
+
+    $data = [
+        'codigo' => $_POST['codigo'],
+        'nombre' => $_POST['nombre'],
+        'descripcion' => $_POST['descripcion']
+    ];
+
+    if ($is_editing) {
+        $data['estado'] = isset($_POST['estado']) ? (int)$_POST['estado'] : 0;
+    }
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $is_editing ? 'PUT' : 'POST');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error.');
+
+    header("Location: tipos_documentos.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: tipos_documentos.php');
+    exit();
+}
+?>


### PR DESCRIPTION
This commit introduces two new maintenance modules for managing document types based on SUNAT standards.

1.  **Identity Document Types CRUD:**
    *   Adds a new database table `tipo_documento_identidad` with corresponding stored procedures for full CRUD operations.
    *   Includes initial data for common identity documents (DNI, RUC, etc.).
    *   Implements a backend API endpoint and a model for handling the logic.
    *   Creates a user interface in the frontend for listing, creating, editing, and deleting identity document types, including a status field.

2.  **Sale Document Types CRUD:**
    *   Adds a new database table `tipo_documento_venta` with corresponding stored procedures.
    *   Includes initial data for common sale documents (Factura, Boleta, etc.).
    *   Implements a backend API endpoint and a model.
    *   Creates a user interface in the frontend for managing sale document types with a status field.

Also includes a migration script to set up and update the database schema.