### PR TITLE
feat: Add CRUD modules for Empresa and Series Documentos

### DIFF
--- a/backend/api/v1/series_documentos.php
+++ b/backend/api/v1/series_documentos.php
@@ -1,0 +1,95 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../models/SerieDocumento.php';
+
+$serieDocumento = new SerieDocumento();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            $serie_id = intval($_GET["id"]);
+            $serie_data = $serieDocumento->readOne($serie_id);
+            if ($serie_data) {
+                http_response_code(200);
+                echo json_encode($serie_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Serie no encontrada."]);
+            }
+        } else {
+            $stmt = $serieDocumento->readAll();
+            $num = $stmt->rowCount();
+            if ($num > 0) {
+                $series_arr = ["records" => []];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    $row['estado'] = (bool)$row['estado'];
+                    array_push($series_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($series_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode(["records" => []]);
+            }
+        }
+        break;
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->id_tipo_documento) && !empty($data->serie)) {
+            $stmt = $serieDocumento->create($data->id_tipo_documento, $data->serie);
+            if ($stmt) {
+                $new_serie = $stmt->fetch(PDO::FETCH_ASSOC);
+                http_response_code(201);
+                echo json_encode(["message" => "Serie creada.", "id" => $new_serie['id']]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear la serie."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        $serie_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+        if ($serie_id && !empty($data->id_tipo_documento) && !empty($data->serie)) {
+            $estado = isset($data->estado) ? (bool)$data->estado : true;
+            if ($serieDocumento->update($serie_id, $data->id_tipo_documento, $data->serie, $estado)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Serie actualizada."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar la serie."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+    case 'DELETE':
+        $serie_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+        if ($serie_id) {
+            if ($serieDocumento->delete($serie_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Serie eliminada."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar la serie."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+?>

--- a/backend/migrations/20250921_add_series_documentos.sql
+++ b/backend/migrations/20250921_add_series_documentos.sql
@@ -1,0 +1,89 @@
+-- Migration to add series_documentos table and procedures
+
+-- -----------------------------------------------------
+-- Table `series_documentos`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `series_documentos` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `id_tipo_documento` INT NOT NULL,
+  `serie` VARCHAR(10) NOT NULL,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE,
+  CONSTRAINT `fk_series_tipo_documento`
+    FOREIGN KEY (`id_tipo_documento`)
+    REFERENCES `tipo_documento_venta` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------------------------------------
+-- Stored Procedures for `series_documentos`
+-- -----------------------------------------------------
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_getAllSeries`$$
+CREATE PROCEDURE `sp_getAllSeries`()
+BEGIN
+    SELECT
+        s.id,
+        s.id_tipo_documento,
+        tdv.nombre AS nombre_tipo_documento,
+        s.serie,
+        s.estado
+    FROM
+        `series_documentos` s
+    JOIN
+        `tipo_documento_venta` tdv ON s.id_tipo_documento = tdv.id
+    ORDER BY
+        tdv.nombre, s.serie;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_getOneSerie`$$
+CREATE PROCEDURE `sp_getOneSerie`(IN p_id INT)
+BEGIN
+    SELECT
+        s.id,
+        s.id_tipo_documento,
+        tdv.nombre AS nombre_tipo_documento,
+        s.serie,
+        s.estado
+    FROM
+        `series_documentos` s
+    JOIN
+        `tipo_documento_venta` tdv ON s.id_tipo_documento = tdv.id
+    WHERE
+        s.id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_createSerie`$$
+CREATE PROCEDURE `sp_createSerie`(
+    IN p_id_tipo_documento INT,
+    IN p_serie VARCHAR(10)
+)
+BEGIN
+    INSERT INTO `series_documentos` (id_tipo_documento, serie, estado)
+    VALUES (p_id_tipo_documento, p_serie, TRUE);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_updateSerie`$$
+CREATE PROCEDURE `sp_updateSerie`(
+    IN p_id INT,
+    IN p_id_tipo_documento INT,
+    IN p_serie VARCHAR(10),
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE `series_documentos`
+    SET
+        id_tipo_documento = p_id_tipo_documento,
+        serie = p_serie,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_deleteSerie`$$
+CREATE PROCEDURE `sp_deleteSerie`(IN p_id INT)
+BEGIN
+    DELETE FROM `series_documentos` WHERE id = p_id;
+END$$
+
+DELIMITER ;

--- a/backend/models/SerieDocumento.php
+++ b/backend/models/SerieDocumento.php
@@ -1,0 +1,54 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class SerieDocumento {
+    private $conn;
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    public function readAll() {
+        $query = "CALL sp_getAllSeries()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    public function readOne($id) {
+        $query = "CALL sp_getOneSerie(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($id_tipo_documento, $serie) {
+        $query = "CALL sp_createSerie(:id_tipo_documento, :serie)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id_tipo_documento', $id_tipo_documento);
+        $stmt->bindParam(':serie', $serie);
+        if ($stmt->execute()) {
+            return $stmt;
+        }
+        return false;
+    }
+
+    public function update($id, $id_tipo_documento, $serie, $estado) {
+        $query = "CALL sp_updateSerie(:id, :id_tipo_documento, :serie, :estado)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':id_tipo_documento', $id_tipo_documento);
+        $stmt->bindParam(':serie', $serie);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+        return $stmt->execute();
+    }
+
+    public function delete($id) {
+        $query = "CALL sp_deleteSerie(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        return $stmt->execute();
+    }
+}
+?>

--- a/frontend_web/serie_documento_delete_handler.php
+++ b/frontend_web/serie_documento_delete_handler.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    require_once 'config.php';
+    $serie_id = intval($_GET['id']);
+    $api_url = API_BASE_URL . 'series_documentos.php?id=' . $serie_id;
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error al eliminar.');
+
+    header("Location: series_documentos.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: series_documentos.php');
+    exit();
+}
+?>

--- a/frontend_web/serie_documento_form.php
+++ b/frontend_web/serie_documento_form.php
@@ -1,0 +1,87 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+require_once 'config.php';
+$page_title = 'Crear Serie de Documento';
+$serie_data = ['id' => '', 'id_tipo_documento' => '', 'serie' => '', 'estado' => 1];
+$is_editing = false;
+
+// Fetch document types for the dropdown
+function getDocumentTypes() {
+    $api_url = API_BASE_URL . 'tipos_documentos.php';
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $data = json_decode($response, true);
+        return $data['records'] ?? [];
+    }
+    return [];
+}
+$document_types = getDocumentTypes();
+
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $serie_id = intval($_GET['id']);
+    $page_title = 'Editar Serie de Documento';
+
+    $api_url = API_BASE_URL . "series_documentos.php?id=$serie_id";
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $serie_data = json_decode($response, true);
+    }
+}
+
+include_once 'templates/header.php';
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+                <a href="series_documentos.php" class="btn btn-secondary">Volver a la Lista</a>
+            </div>
+            <div class="form-container">
+                <form action="serie_documento_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($serie_data['id']); ?>">
+
+                    <div class="form-group">
+                        <label for="id_tipo_documento">Tipo de Documento</label>
+                        <select id="id_tipo_documento" name="id_tipo_documento" required>
+                            <option value="">Seleccione un tipo</option>
+                            <?php foreach ($document_types as $type): ?>
+                                <option value="<?php echo $type['id']; ?>" <?php echo ($type['id'] == $serie_data['id_tipo_documento']) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($type['nombre']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="serie">Serie</label>
+                        <input type="text" id="serie" name="serie" value="<?php echo htmlspecialchars($serie_data['serie']); ?>" required maxlength="10">
+                    </div>
+
+                    <?php if ($is_editing): ?>
+                    <div class="form-group">
+                        <label for="estado">Estado</label>
+                        <select id="estado" name="estado">
+                            <option value="1" <?php echo ($serie_data['estado'] == 1) ? 'selected' : ''; ?>>Activo</option>
+                            <option value="0" <?php echo ($serie_data['estado'] == 0) ? 'selected' : ''; ?>>Inactivo</option>
+                        </select>
+                    </div>
+                    <?php endif; ?>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar' : 'Crear'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>

--- a/frontend_web/serie_documento_handler.php
+++ b/frontend_web/serie_documento_handler.php
@@ -1,0 +1,45 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once 'config.php';
+    $is_editing = !empty($_POST['id']);
+    $api_url = API_BASE_URL . 'series_documentos.php';
+    if ($is_editing) {
+        $api_url .= '?id=' . intval($_POST['id']);
+    }
+
+    $data = [
+        'id_tipo_documento' => $_POST['id_tipo_documento'],
+        'serie' => $_POST['serie']
+    ];
+
+    if ($is_editing) {
+        $data['estado'] = isset($_POST['estado']) ? (int)$_POST['estado'] : 0;
+    }
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $is_editing ? 'PUT' : 'POST');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error.');
+
+    header("Location: series_documentos.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: series_documentos.php');
+    exit();
+}
+?>

--- a/frontend_web/series_documentos.php
+++ b/frontend_web/series_documentos.php
@@ -1,22 +1,103 @@
 <?php
 session_start();
-
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
-    header('Location: index.php?error=Por+favor+inicie+sesión');
+    header('Location: index.php');
     exit();
 }
 
-$page_title = 'Series de Documentos';
+$page_title = 'Gestión de Series de Documentos';
 include_once 'templates/header.php';
+
+function getSeries() {
+    require_once 'config.php';
+    $api_url = API_BASE_URL . 'series_documentos.php';
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    return json_decode($response, true);
+}
+
+$series_data = getSeries();
 ?>
 
 <div class="dashboard-container">
     <?php include_once 'templates/sidebar.php'; ?>
-
     <main class="main-content">
         <div class="container">
-            <h1>Series de Documentos</h1>
-            <p>El contenido de la página de series de documentos irá aquí.</p>
+            <div class="page-header">
+                <h1>Catálogo de Series de Documentos</h1>
+                <a href="serie_documento_form.php" class="btn">Crear Serie</a>
+            </div>
+
+            <div class="filters">
+                <input type="text" id="filter-tipo-documento" placeholder="Filtrar por Tipo de Documento...">
+                <input type="text" id="filter-serie" placeholder="Filtrar por Serie...">
+            </div>
+
+            <div class="table-container">
+                <table id="series-table">
+                    <thead>
+                        <tr>
+                            <th>Tipo de Documento</th>
+                            <th>Serie</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (isset($series_data['records']) && !empty($series_data['records'])): ?>
+                            <?php foreach ($series_data['records'] as $serie): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($serie['nombre_tipo_documento']); ?></td>
+                                    <td><?php echo htmlspecialchars($serie['serie']); ?></td>
+                                    <td>
+                                        <span class="status <?php echo $serie['estado'] ? 'status-active' : 'status-inactive'; ?>">
+                                            <?php echo $serie['estado'] ? 'Activo' : 'Inactivo'; ?>
+                                        </span>
+                                    </td>
+                                    <td class="actions-cell">
+                                        <a href="serie_documento_form.php?id=<?php echo $serie['id']; ?>" class="btn btn-edit">Editar</a>
+                                        <a href="serie_documento_delete_handler.php?id=<?php echo $serie['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro?');">Eliminar</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr><td colspan="4">No se encontraron series de documentos.</td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </main>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const filterTipo = document.getElementById('filter-tipo-documento');
+    const filterSerie = document.getElementById('filter-serie');
+    const tableRows = document.querySelectorAll('#series-table tbody tr');
+
+    function filterTable() {
+        const tipoText = filterTipo.value.toLowerCase();
+        const serieText = filterSerie.value.toLowerCase();
+
+        tableRows.forEach(row => {
+            const tipoCell = row.cells[0].textContent.toLowerCase();
+            const serieCell = row.cells[1].textContent.toLowerCase();
+
+            const matchesTipo = tipoCell.includes(tipoText);
+            const matchesSerie = serieCell.includes(serieText);
+
+            if (matchesTipo && matchesSerie) {
+                row.style.display = '';
+            } else {
+                row.style.display = 'none';
+            }
+        });
+    }
+
+    filterTipo.addEventListener('keyup', filterTable);
+    filterSerie.addEventListener('keyup', filterTable);
+});
+</script>


### PR DESCRIPTION
This commit introduces two new full-featured maintenance modules and completes the implementation of two others, significantly expanding the system's master data management capabilities.

1.  **New Empresa (Company) CRUD:**
    *   Implements a complete CRUD for managing company information.
    *   Adds a new `empresas` table and tables for Peruvian Ubigeo data (departments, provinces, districts).
    *   The frontend form includes dynamic, three-level dependent dropdowns for Ubigeo and a component for uploading, previewing, and removing the company logo.
    *   Adds a new "Empresa" link to the "Maestros" section of the sidebar.

2.  **New Series Documentos CRUD:**
    *   Implements a CRUD to create and manage custom document series (e.g., F001, B001) and associate them with sale document types.
    *   Includes a new `series_documentos` table, a backend model, and an API endpoint.
    *   The frontend features a grid view with filters and a form for creating and editing series.

3.  **Document Type CRUDs Finalization:**
    *   Completes the full implementation of the "Tipos de Documento de Identidad" and "Tipos de Documento de Venta" modules, transforming them from placeholders into functional CRUDs.

All new database objects are managed through separate, versioned SQL migration files.