### PR TITLE
feat: Implement editable price and observations for service products

### DIFF
--- a/backend/database.sql
+++ b/backend/database.sql
@@ -169,7 +169,18 @@ END$$
 DROP PROCEDURE IF EXISTS sp_getOrderItems$$
 CREATE PROCEDURE sp_getOrderItems(IN p_id_pedido INT)
 BEGIN
-    SELECT dp.id_producto, pr.nombre AS nombre_producto, dp.cantidad, dp.precio_unitario, dp.subtotal FROM detalle_pedidos dp JOIN productos pr ON dp.id_producto = pr.id WHERE dp.id_pedido = p_id_pedido;
+    SELECT
+        dp.id_producto,
+        pr.nombre AS nombre_producto,
+        dp.cantidad,
+        dp.precio_unitario,
+        dp.subtotal,
+        dp.observaciones,
+        cp.tipo as categoria_tipo
+    FROM detalle_pedidos dp
+    JOIN productos pr ON dp.id_producto = pr.id
+    LEFT JOIN categorias_producto cp ON pr.id_categoria = cp.id
+    WHERE dp.id_pedido = p_id_pedido;
 END$$
 
 DROP PROCEDURE IF EXISTS sp_createOrder$$

--- a/backend/migrations/20250921_features.sql
+++ b/backend/migrations/20250921_features.sql
@@ -32,20 +32,36 @@ BEGIN
     DECLARE v_id_producto INT;
     DECLARE v_cantidad INT;
     DECLARE v_precio_unitario DECIMAL(10, 2);
+    DECLARE v_observaciones TEXT;
     DECLARE i INT DEFAULT 0;
+
     START TRANSACTION;
+
     DELETE FROM detalle_pedidos WHERE id_pedido = p_id_pedido;
+
     WHILE i < JSON_LENGTH(p_items_json) DO
         SET v_item = JSON_EXTRACT(p_items_json, CONCAT('$[', i, ']'));
         SET v_id_producto = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.id'));
         SET v_cantidad = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.cantidad'));
-        SELECT precio INTO v_precio_unitario FROM productos WHERE id = v_id_producto;
-        INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario)
-        VALUES (p_id_pedido, v_id_producto, v_cantidad, v_precio_unitario);
+        SET v_precio_unitario = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.precio'));
+        SET v_observaciones = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.observaciones'));
+
+        INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario, observaciones)
+        VALUES (p_id_pedido, v_id_producto, v_cantidad, v_precio_unitario, v_observaciones);
+
         SET v_total_calculado = v_total_calculado + (v_cantidad * v_precio_unitario);
         SET i = i + 1;
     END WHILE;
-    UPDATE pedidos SET id_mesa = p_id_mesa, id_usuario_mozo = p_id_usuario_mozo, estado = p_estado, total = v_total_calculado, fecha_actualizacion = CURRENT_TIMESTAMP WHERE id = p_id_pedido;
+
+    UPDATE pedidos
+    SET
+        id_mesa = p_id_mesa,
+        id_usuario_mozo = p_id_usuario_mozo,
+        estado = p_estado,
+        total = v_total_calculado,
+        fecha_actualizacion = CURRENT_TIMESTAMP
+    WHERE id = p_id_pedido;
+
     COMMIT;
 END$$
 

--- a/backend/migrations/20250921_servicios_feature.sql
+++ b/backend/migrations/20250921_servicios_feature.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- MIGRATION SCRIPT FOR SERVICIOS AND OBSERVACIONES
+-- =====================================================
+
+-- 1. Add 'tipo' to 'categorias_producto' table
+ALTER TABLE `categorias_producto`
+ADD COLUMN `tipo` ENUM('bienes', 'servicios') NOT NULL DEFAULT 'bienes' COMMENT 'Define si la categoría es de bienes tangibles o servicios.';
+
+-- 2. Add 'observaciones' to 'detalle_pedidos' table
+ALTER TABLE `detalle_pedidos`
+ADD COLUMN `observaciones` TEXT COMMENT 'Observaciones adicionales para el item del pedido, útil para servicios.';

--- a/backend/update_productos_add_status.sql
+++ b/backend/update_productos_add_status.sql
@@ -22,7 +22,7 @@ BEGIN
     DECLARE v_offset INT;
     SET v_offset = (p_page_number - 1) * p_page_size;
 
-    SELECT p.id, p.nombre, p.descripcion, p.precio, p.estado, c.nombre as categoria_nombre
+    SELECT p.id, p.nombre, p.descripcion, p.precio, p.estado, c.nombre as categoria_nombre, c.tipo as categoria_tipo
     FROM productos p
     LEFT JOIN categorias_producto c ON p.id_categoria = c.id
     WHERE
@@ -81,7 +81,7 @@ END$$
 DROP PROCEDURE IF EXISTS sp_readOneProduct$$
 CREATE PROCEDURE sp_readOneProduct(IN p_id INT)
 BEGIN
-    SELECT p.id, p.nombre, p.descripcion, p.precio, p.id_categoria, p.estado, c.nombre as categoria_nombre
+    SELECT p.id, p.nombre, p.descripcion, p.precio, p.id_categoria, p.estado, c.nombre as categoria_nombre, c.tipo as categoria_tipo
     FROM productos p
     LEFT JOIN categorias_producto c ON p.id_categoria = c.id
     WHERE p.id = p_id;
@@ -89,7 +89,7 @@ END$$
 
 -- Update stored procedure for creating orders to only use active products
 DROP PROCEDURE IF EXISTS sp_createOrder$$
-CREATE PROCEDURE sp_createOrder(IN p_id_mesa INT, IN p_id_usuario_mozo INT, IN p_items_json JSON)
+CREATE PROCEDURE sp_createOrder(IN p_id_mesa INT, IN p_id_usuario_mozo INT, IN p_items_json JSON, IN p_estado VARCHAR(50))
 BEGIN
     DECLARE v_id_pedido INT;
     DECLARE v_total_calculado DECIMAL(10, 2) DEFAULT 0;
@@ -97,23 +97,39 @@ BEGIN
     DECLARE v_id_producto INT;
     DECLARE v_cantidad INT;
     DECLARE v_precio_unitario DECIMAL(10, 2);
+    DECLARE v_observaciones TEXT;
+    DECLARE v_is_product_active BOOLEAN;
     DECLARE i INT DEFAULT 0;
+
     START TRANSACTION;
-    INSERT INTO pedidos (id_mesa, id_usuario_mozo, total) VALUES (p_id_mesa, p_id_usuario_mozo, 0);
+
+    INSERT INTO pedidos (id_mesa, id_usuario_mozo, estado, total) VALUES (p_id_mesa, p_id_usuario_mozo, p_estado, 0);
     SET v_id_pedido = LAST_INSERT_ID();
+
     WHILE i < JSON_LENGTH(p_items_json) DO
         SET v_item = JSON_EXTRACT(p_items_json, CONCAT('$[', i, ']'));
         SET v_id_producto = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.id'));
         SET v_cantidad = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.cantidad'));
-        SELECT precio INTO v_precio_unitario FROM productos WHERE id = v_id_producto AND estado = 'activo';
-        IF v_precio_unitario IS NOT NULL THEN
-            INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario) VALUES (v_id_pedido, v_id_producto, v_cantidad, v_precio_unitario);
+        SET v_precio_unitario = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.precio'));
+        SET v_observaciones = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.observaciones'));
+
+        -- Verify the product is active before adding it to the order
+        SELECT (estado = 'activo') INTO v_is_product_active FROM productos WHERE id = v_id_producto;
+
+        IF v_is_product_active THEN
+            INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario, observaciones)
+            VALUES (v_id_pedido, v_id_producto, v_cantidad, v_precio_unitario, v_observaciones);
+
             SET v_total_calculado = v_total_calculado + (v_cantidad * v_precio_unitario);
         END IF;
+
         SET i = i + 1;
     END WHILE;
+
     UPDATE pedidos SET total = v_total_calculado WHERE id = v_id_pedido;
+
     COMMIT;
+
     SELECT v_id_pedido as id;
 END$$
 

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -107,6 +107,7 @@ if ($is_pago_view) {
                                  data-id="<?php echo $producto['id']; ?>"
                                  data-nombre="<?php echo htmlspecialchars($producto['nombre']); ?>"
                                  data-precio="<?php echo $producto['precio']; ?>"
+                                 data-categoria-tipo="<?php echo htmlspecialchars($producto['categoria_tipo']); ?>"
                                  data-category="<?php echo htmlspecialchars($producto['categoria_nombre']); ?>">
                                 <h4><?php echo htmlspecialchars($producto['nombre']); ?></h4>
                                 <p><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($producto['precio'], 2)); ?></p>
@@ -243,8 +244,46 @@ document.addEventListener('DOMContentLoaded', function() {
             const item = currentOrder[productId];
             const subtotal = item.precio * item.cantidad;
             total += subtotal;
-            tableBody.innerHTML += `<tr><td>${item.nombre}</td><td><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></td><td>${currencySymbol}${item.precio.toFixed(2)}</td><td>${currencySymbol}${subtotal.toFixed(2)}</td><td><button type="button" class="btn-delete delete-item" data-id="${item.id}">X</button></td></tr>`;
-            cardsContainer.innerHTML += `<div class="order-item-card"><div class="card-item-header">${item.nombre}</div><div class="card-item-body"><div class="card-item-row"><span>Precio:</span><span>${currencySymbol}${item.precio.toFixed(2)}</span></div><div class="card-item-row"><span>Cantidad:</span><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></div><div class="card-item-row"><span>Subtotal:</span><strong>${currencySymbol}${subtotal.toFixed(2)}</strong></div></div><div class="card-item-footer"><button type="button" class="btn-delete delete-item" data-id="${item.id}">Eliminar</button></div></div>`;
+
+            const isService = item.categoria_tipo === 'servicios';
+
+            const priceInput = isService
+                ? `<input type="number" class="item-price" value="${item.precio.toFixed(2)}" data-id="${item.id}" step="0.01">`
+                : `${currencySymbol}${item.precio.toFixed(2)}`;
+
+            const obsRow = isService
+                ? `<tr class="observation-row"><td colspan="5"><textarea class="item-observaciones" data-id="${item.id}" placeholder="Observaciones">${item.observaciones || ''}</textarea></td></tr>`
+                : '';
+
+            // Desktop Table Row
+            tableBody.innerHTML += `
+                <tr>
+                    <td>${item.nombre}</td>
+                    <td><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></td>
+                    <td>${priceInput}</td>
+                    <td>${currencySymbol}${subtotal.toFixed(2)}</td>
+                    <td><button type="button" class="btn-delete delete-item" data-id="${item.id}">X</button></td>
+                </tr>
+                ${obsRow}`;
+
+            // Mobile Card
+            const cardObsRow = isService
+                ? `<div class="card-item-row"><span>Obs:</span><textarea class="item-observaciones" data-id="${item.id}" placeholder="Observaciones">${item.observaciones || ''}</textarea></div>`
+                : '';
+
+            cardsContainer.innerHTML += `
+                <div class="order-item-card">
+                    <div class="card-item-header">${item.nombre}</div>
+                    <div class="card-item-body">
+                        <div class="card-item-row"><span>Precio:</span><span>${priceInput}</span></div>
+                        <div class="card-item-row"><span>Cantidad:</span><input type="number" class="item-quantity" value="${item.cantidad}" min="1" data-id="${item.id}"></div>
+                        ${cardObsRow}
+                        <div class="card-item-row"><span>Subtotal:</span><strong>${currencySymbol}${subtotal.toFixed(2)}</strong></div>
+                    </div>
+                    <div class="card-item-footer">
+                        <button type="button" class="btn-delete delete-item" data-id="${item.id}">Eliminar</button>
+                    </div>
+                </div>`;
         }
         orderTotalElement.textContent = `${currencySymbol}${total.toFixed(2)}`;
     }
@@ -262,6 +301,7 @@ document.addEventListener('DOMContentLoaded', function() {
             productItem.dataset.nombre = product.nombre;
             productItem.dataset.precio = product.precio;
             productItem.dataset.category = product.categoria_nombre;
+            productItem.dataset.categoriaTipo = product.categoria_tipo;
             productItem.innerHTML = `<h4>${product.nombre}</h4><p>${currencySymbol}${parseFloat(product.precio).toFixed(2)}</p>`;
             productList.appendChild(productItem);
         });
@@ -298,7 +338,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 id: item.id_producto,
                 nombre: item.nombre_producto,
                 precio: parseFloat(item.precio_unitario),
-                cantidad: parseInt(item.cantidad, 10)
+                cantidad: parseInt(item.cantidad, 10),
+                categoria_tipo: item.categoria_tipo,
+                observaciones: item.observaciones
             };
         });
         renderOrderItems();
@@ -316,7 +358,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 id: productId,
                 nombre: productItem.dataset.nombre,
                 precio: parseFloat(productItem.dataset.precio),
-                cantidad: 1
+                cantidad: 1,
+                categoria_tipo: productItem.dataset.categoriaTipo,
+                observaciones: ''
             };
         }
         renderOrderItems();
@@ -330,16 +374,22 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     orderDetailsContainer.addEventListener('input', function(e) {
+        const productId = e.target.dataset.id;
+        if (!currentOrder[productId]) return;
+
         if (e.target.classList.contains('item-quantity')) {
             const newQuantity = parseInt(e.target.value, 10);
-            const productId = e.target.dataset.id;
             if (newQuantity > 0) {
                 currentOrder[productId].cantidad = newQuantity;
             } else {
                 delete currentOrder[productId];
             }
-            renderOrderItems();
+        } else if (e.target.classList.contains('item-price')) {
+            currentOrder[productId].precio = parseFloat(e.target.value) || 0;
+        } else if (e.target.classList.contains('item-observaciones')) {
+            currentOrder[productId].observaciones = e.target.value;
         }
+        renderOrderItems();
     });
 
     document.querySelectorAll('.status-btn').forEach(button => {


### PR DESCRIPTION
This feature modifies the order creation and editing process to handle products categorized as 'servicios' (services) differently from 'bienes' (goods).

- Adds a `tipo` ENUM('bienes', 'servicios') column to the `categorias_producto` table to distinguish between category types.
- Adds an `observaciones` TEXT column to the `detalle_pedidos` table to store notes for order items.
- Creates a new SQL migration file for these database schema changes.
- Updates all relevant stored procedures (`sp_getAllProducts`, `sp_createOrder`, `sp_updateOrder`, `sp_getOrderItems`) to support the new fields and logic.
- Implements frontend JavaScript logic in `pedido_form.php` to:
  - Make the price field an editable input for service products.
  - Display a multi-line textarea for observations only for service products.
  - Ensure that edited prices and observations are correctly captured and saved when creating or updating an order.
- Fixes a pre-existing bug where the UI for managing category types was present but non-functional due to the missing database column.