### PR TITLE
fix: Corregir lógica para productos de tipo servicio en pedidos

### DIFF
--- a/backend/database.sql
+++ b/backend/database.sql
@@ -176,7 +176,7 @@ BEGIN
         dp.precio_unitario,
         dp.subtotal,
         dp.observaciones,
-        cp.tipo as categoria_tipo
+        cp.tipo_categoria as categoria_tipo
     FROM detalle_pedidos dp
     JOIN productos pr ON dp.id_producto = pr.id
     LEFT JOIN categorias_producto cp ON pr.id_categoria = cp.id

--- a/backend/migrations/20250921_fix_category_schema.sql
+++ b/backend/migrations/20250921_fix_category_schema.sql
@@ -1,0 +1,29 @@
+-- ===============================================================
+-- MIGRATION SCRIPT TO FIX CATEGORY SCHEMA AND RELATED PROCEDURES
+-- ===============================================================
+
+-- 1. Drop the erroneously added 'tipo' column from 'categorias_producto'
+-- This column was added in a previous migration and is redundant. The correct column is 'tipo_categoria'.
+ALTER TABLE `categorias_producto` DROP COLUMN `tipo`;
+
+-- The following stored procedures need to be updated to use 'tipo_categoria' instead of 'tipo'.
+-- This script serves as documentation for the changes that will be applied to other SQL files.
+
+/*
+-- In backend/update_productos_add_status.sql:
+
+-- sp_getAllProducts should be updated to:
+SELECT p.id, p.nombre, p.descripcion, p.precio, p.estado, c.nombre as categoria_nombre, c.tipo_categoria as categoria_tipo
+...
+
+-- sp_readOneProduct should be updated to:
+SELECT p.id, p.nombre, p.descripcion, p.precio, p.id_categoria, p.estado, c.nombre as categoria_nombre, c.tipo_categoria as categoria_tipo
+...
+
+-- In backend/database.sql:
+
+-- sp_getOrderItems should be updated to:
+SELECT ..., cp.tipo_categoria as categoria_tipo
+...
+
+*/

--- a/backend/update_productos_add_status.sql
+++ b/backend/update_productos_add_status.sql
@@ -22,7 +22,7 @@ BEGIN
     DECLARE v_offset INT;
     SET v_offset = (p_page_number - 1) * p_page_size;
 
-    SELECT p.id, p.nombre, p.descripcion, p.precio, p.estado, c.nombre as categoria_nombre, c.tipo as categoria_tipo
+    SELECT p.id, p.nombre, p.descripcion, p.precio, p.estado, c.nombre as categoria_nombre, c.tipo_categoria as categoria_tipo
     FROM productos p
     LEFT JOIN categorias_producto c ON p.id_categoria = c.id
     WHERE
@@ -81,7 +81,7 @@ END$$
 DROP PROCEDURE IF EXISTS sp_readOneProduct$$
 CREATE PROCEDURE sp_readOneProduct(IN p_id INT)
 BEGIN
-    SELECT p.id, p.nombre, p.descripcion, p.precio, p.id_categoria, p.estado, c.nombre as categoria_nombre, c.tipo as categoria_tipo
+    SELECT p.id, p.nombre, p.descripcion, p.precio, p.id_categoria, p.estado, c.nombre as categoria_nombre, c.tipo_categoria as categoria_tipo
     FROM productos p
     LEFT JOIN categorias_producto c ON p.id_categoria = c.id
     WHERE p.id = p_id;

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -245,7 +245,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const subtotal = item.precio * item.cantidad;
             total += subtotal;
 
-            const isService = item.categoria_tipo === 'servicios';
+            const isService = item.categoria_tipo === 'Servicios';
 
             const priceInput = isService
                 ? `<input type="number" class="item-price" value="${item.precio.toFixed(2)}" data-id="${item.id}" step="0.01">`


### PR DESCRIPTION
Esta corrección soluciona los problemas de la implementación anterior y asegura que los productos de tipo 'Servicio' se manejen correctamente en el formulario de pedidos.

- Corrige el esquema de la base de datos eliminando la columna `tipo` duplicada y redundante de la tabla `categorias_producto`.
- Actualiza todos los procedimientos almacenados relevantes (`sp_getAllProducts`, `sp_readOneProduct`, `sp_getOrderItems`) para que utilicen la columna correcta `tipo_categoria`.
- Ajusta la lógica de JavaScript en `pedido_form.php` para que la comparación de tipos sea sensible a mayúsculas y minúsculas (usando 'Servicios' en lugar de 'servicios'), lo que soluciona el error que impedía que la interfaz de usuario se actualizara.
- Verifica la consistencia de todo el CRUD de categorías para asegurar que solo se utiliza el campo `tipo_categoria`.