### PR TITLE
This commit adds functionality to the "Sunat" button in the client form.

### DIFF
--- a/frontend_web/cliente_form.php
+++ b/frontend_web/cliente_form.php
@@ -55,7 +55,10 @@ $document_types = getIdentityDocumentTypes();
                         <select id="id_tipo_documento_identidad" name="id_tipo_documento_identidad" required>
                             <option value="">Seleccione...</option>
                             <?php foreach ($document_types as $type): ?>
-                                <option value="<?php echo $type['id']; ?>" <?php echo ($cliente['id_tipo_documento_identidad'] == $type['id']) ? 'selected' : ''; ?>>
+                                <option
+                                    value="<?php echo $type['id']; ?>"
+                                    data-codigo="<?php echo htmlspecialchars($type['codigo']); ?>"
+                                    <?php echo ($cliente['id_tipo_documento_identidad'] == $type['id']) ? 'selected' : ''; ?>>
                                     <?php echo htmlspecialchars($type['nombre']); ?>
                                 </option>
                             <?php endforeach; ?>
@@ -66,7 +69,7 @@ $document_types = getIdentityDocumentTypes();
                         <label for="numero_documento">N° de Documento</label>
                         <div style="display: flex; gap: 10px;">
                             <input type="text" id="numero_documento" name="numero_documento" value="<?php echo htmlspecialchars($cliente['numero_documento']); ?>" required style="flex-grow: 1;">
-                            <button type="button" class="btn" id="sunat-btn" style="flex-shrink: 0;">Sunat</button>
+                            <button type="button" class="btn" id="sunat-btn" style="flex-shrink: 0; display: none;">Sunat</button>
                         </div>
                     </div>
 
@@ -115,16 +118,78 @@ $document_types = getIdentityDocumentTypes();
 </div>
 
 <script>
-// Placeholder for SUNAT API call
-document.getElementById('sunat-btn').addEventListener('click', function() {
-    const docNumber = document.getElementById('numero_documento').value;
-    if(docNumber) {
-        alert('Consultando a SUNAT/RENIEC con el número: ' + docNumber);
-        // Here you would typically make an API call to a government service
-        // and populate fields like 'nombres_apellidos' and 'direccion'.
-        // For this example, we'll just show an alert.
-    } else {
-        alert('Por favor, ingrese un número de documento.');
+document.addEventListener('DOMContentLoaded', function() {
+    const tipoDocumentoSelect = document.getElementById('id_tipo_documento_identidad');
+    const sunatBtn = document.getElementById('sunat-btn');
+    const numeroDocumentoInput = document.getElementById('numero_documento');
+    const nombresInput = document.getElementById('nombres_apellidos');
+    const direccionInput = document.getElementById('direccion');
+    const ubigeoInput = document.getElementById('codigo_ubigeo');
+
+    const validDocumentCodes = ['1', '6']; // 1 for DNI, 6 for RUC
+
+    function toggleSunatButton() {
+        const selectedOption = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex];
+        const docCode = selectedOption ? selectedOption.getAttribute('data-codigo') : null;
+
+        if (docCode && validDocumentCodes.includes(docCode)) {
+            sunatBtn.style.display = 'inline-block';
+        } else {
+            sunatBtn.style.display = 'none';
+        }
     }
+
+    sunatBtn.addEventListener('click', function() {
+        const selectedOption = tipoDocumentoSelect.options[tipoDocumentoSelect.selectedIndex];
+        const docCode = selectedOption ? selectedOption.getAttribute('data-codigo') : null;
+        const docNumber = numeroDocumentoInput.value.trim();
+
+        if (!docCode || !docNumber) {
+            alert('Por favor, seleccione un tipo de documento y ingrese un número.');
+            return;
+        }
+
+        let queryType = '';
+        if (docCode === '1') {
+            queryType = 'dni';
+        } else if (docCode === '6') {
+            queryType = 'ruc';
+        } else {
+            return; // Should not happen if button is only visible for DNI/RUC
+        }
+
+        sunatBtn.textContent = 'Buscando...';
+        sunatBtn.disabled = true;
+
+        fetch(`consulta_api_externa.php?tipo=${queryType}&numero=${docNumber}`)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('La respuesta de la red no fue exitosa.');
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data.error) {
+                    throw new Error(data.error);
+                }
+                nombresInput.value = data.nombre || '';
+                direccionInput.value = data.direccion || '';
+                ubigeoInput.value = data.ubigeo || '';
+            })
+            .catch(error => {
+                console.error('Error al consultar la API:', error);
+                alert('No se pudo obtener la información: ' + error.message);
+            })
+            .finally(() => {
+                sunatBtn.textContent = 'Sunat';
+                sunatBtn.disabled = false;
+            });
+    });
+
+    // Initial check on page load
+    toggleSunatButton();
+
+    // Add event listener for changes
+    tipoDocumentoSelect.addEventListener('change', toggleSunatButton);
 });
 </script>

--- a/frontend_web/consulta_api_externa.php
+++ b/frontend_web/consulta_api_externa.php
@@ -1,0 +1,56 @@
+<?php
+header("Content-Type: application/json; charset=UTF-8");
+
+// Simple token-based security. In a real app, use something more robust.
+// This is just to prevent wide-open access. A real implementation
+// might use session-based authentication.
+// For now, this token is not required, but it's a placeholder for better security.
+$EXPECTED_TOKEN = "un-token-secreto-muy-seguro";
+
+if (!isset($_GET['tipo']) || !isset($_GET['numero'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Parámetros tipo y numero son requeridos.']);
+    exit;
+}
+
+$tipo = strtolower($_GET['tipo']);
+$numero = $_GET['numero'];
+$base_url = 'https://api.apis.net.pe/v1/';
+$api_url = '';
+
+if ($tipo === 'ruc') {
+    $api_url = $base_url . 'ruc?numero=' . urlencode($numero);
+} elseif ($tipo === 'dni') {
+    $api_url = $base_url . 'dni?numero=' . urlencode($numero);
+} else {
+    http_response_code(400);
+    echo json_encode(['error' => 'Tipo de consulta no válido. Use "ruc" o "dni".']);
+    exit;
+}
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $api_url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+// Optional: Add an Authorization header if the API requires it.
+// curl_setopt($ch, CURLOPT_HTTPHEADER, array('Authorization: Bearer YOUR_API_TOKEN'));
+curl_setopt($ch, CURLOPT_TIMEOUT, 10); // 10-second timeout
+
+$response = curl_exec($ch);
+$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$curl_error = curl_error($ch);
+curl_close($ch);
+
+if ($curl_error) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error en la consulta a la API externa.', 'details' => $curl_error]);
+    exit;
+}
+
+if ($httpcode >= 400) {
+    // Forward the status code from the external API
+    http_response_code($httpcode);
+}
+
+// Return the response from the external API directly to the client
+echo $response;
+?>


### PR DESCRIPTION
- A new backend proxy `consulta_api_externa.php` is created to handle calls to the external `api.apis.net.pe` service for DNI and RUC lookups.
- The client form now includes JavaScript to:
  - Show the "Sunat" button only when the document type is DNI or RUC.
  - Call the backend proxy when the button is clicked.
  - Populate the 'Nombres y Apellidos', 'Dirección', and 'Código de Ubigeo' fields with the data returned from the API.