### PR TITLE
feat: Add customer tab to order page

### DIFF
--- a/backend/api/v1/clientes.php
+++ b/backend/api/v1/clientes.php
@@ -21,6 +21,21 @@ switch ($request_method) {
                 http_response_code(404);
                 echo json_encode(["message" => "Cliente no encontrado."]);
             }
+        } else if (!empty($_GET["search"])) {
+            $search_term = htmlspecialchars(strip_tags($_GET["search"]));
+            $stmt = $cliente->search($search_term);
+            $num = $stmt->rowCount();
+            if ($num > 0) {
+                $clientes_arr = ["records" => []];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    array_push($clientes_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($clientes_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode(["records" => []]);
+            }
         } else {
             $stmt = $cliente->readAll();
             $num = $stmt->rowCount();

--- a/backend/api/v1/pedidos.php
+++ b/backend/api/v1/pedidos.php
@@ -29,7 +29,9 @@ switch ($request_method) {
     case 'POST':
         $data = json_decode(file_get_contents("php://input"));
         if (!empty($data->id_mesa) && !empty($data->id_usuario_mozo) && !empty($data->items) && is_array($data->items) && !empty($data->estado)) {
-            $stmt = $order->create($data->id_mesa, $data->id_usuario_mozo, $data->items, $data->estado);
+            $id_cliente = !empty($data->id_cliente) ? $data->id_cliente : null;
+            $id_tipo_comprobante = !empty($data->id_tipo_comprobante) ? $data->id_tipo_comprobante : null;
+            $stmt = $order->create($data->id_mesa, $data->id_usuario_mozo, $data->items, $data->estado, $id_cliente, $id_tipo_comprobante);
             if ($stmt) {
                 $new_order = $stmt->fetch(PDO::FETCH_ASSOC);
                 http_response_code(201);
@@ -48,7 +50,9 @@ switch ($request_method) {
         $data = json_decode(file_get_contents("php://input"));
         $order_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
         if ($order_id && !empty($data->id_mesa) && !empty($data->id_usuario_mozo) && isset($data->estado) && isset($data->items) && is_array($data->items)) {
-            if ($order->update($order_id, $data->id_mesa, $data->id_usuario_mozo, $data->estado, $data->items)) {
+            $id_cliente = !empty($data->id_cliente) ? $data->id_cliente : null;
+            $id_tipo_comprobante = !empty($data->id_tipo_comprobante) ? $data->id_tipo_comprobante : null;
+            if ($order->update($order_id, $data->id_mesa, $data->id_usuario_mozo, $data->estado, $data->items, $id_cliente, $id_tipo_comprobante)) {
                 http_response_code(200);
                 echo json_encode(["message" => "Pedido actualizado exitosamente."]);
             } else {

--- a/backend/api/v1/tipos_documentos.php
+++ b/backend/api/v1/tipos_documentos.php
@@ -41,7 +41,7 @@ switch ($request_method) {
     case 'POST':
         $data = json_decode(file_get_contents("php://input"));
         if (!empty($data->codigo) && !empty($data->nombre)) {
-            $stmt = $saleDocumentType->create($data->codigo, $data->nombre, $data->descripcion ?? '');
+            $stmt = $saleDocumentType->create($data->codigo, $data->nombre);
             if ($stmt) {
                 $new_type = $stmt->fetch(PDO::FETCH_ASSOC);
                 http_response_code(201);
@@ -60,7 +60,7 @@ switch ($request_method) {
         $type_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
         if ($type_id && !empty($data->codigo) && !empty($data->nombre)) {
             $estado = isset($data->estado) ? (bool)$data->estado : true;
-            if ($saleDocumentType->update($type_id, $data->codigo, $data->nombre, $data->descripcion ?? '', $estado)) {
+            if ($saleDocumentType->update($type_id, $data->codigo, $data->nombre, $estado)) {
                 http_response_code(200);
                 echo json_encode(["message" => "Tipo de documento actualizado."]);
             } else {

--- a/backend/migrations/20240921_add_cliente_to_pedidos.sql
+++ b/backend/migrations/20240921_add_cliente_to_pedidos.sql
@@ -1,0 +1,157 @@
+-- Migration script for adding customer and document type to orders
+
+-- -----------------------------------------------------
+-- Table `tipos_comprobante`
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS `tipos_comprobante`;
+
+CREATE TABLE `tipos_comprobante` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `codigo` VARCHAR(2) NOT NULL,
+  `nombre` VARCHAR(50) NOT NULL,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `codigo_UNIQUE` (`codigo` ASC)
+) ENGINE = InnoDB;
+
+-- -----------------------------------------------------
+-- Initial data for `tipos_comprobante`
+-- -----------------------------------------------------
+INSERT INTO `tipos_comprobante` (`codigo`, `nombre`) VALUES
+('01', 'Factura'),
+('03', 'Boleta de Venta');
+
+-- -----------------------------------------------------
+-- Modify `pedidos` table
+-- -----------------------------------------------------
+ALTER TABLE `pedidos`
+ADD COLUMN `id_cliente` INT NULL,
+ADD COLUMN `id_tipo_comprobante` INT NULL,
+ADD CONSTRAINT `fk_pedidos_clientes`
+  FOREIGN KEY (`id_cliente`)
+  REFERENCES `clientes` (`id`)
+  ON DELETE SET NULL
+  ON UPDATE CASCADE,
+ADD CONSTRAINT `fk_pedidos_tipos_comprobante`
+  FOREIGN KEY (`id_tipo_comprobante`)
+  REFERENCES `tipos_comprobante` (`id`)
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;
+
+-- -----------------------------------------------------
+-- Stored Procedures for `tipos_comprobante`
+-- -----------------------------------------------------
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_getAllTiposComprobante`$$
+CREATE PROCEDURE `sp_getAllTiposComprobante`()
+BEGIN
+    SELECT id, codigo, nombre, estado FROM tipos_comprobante WHERE estado = 1;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_getOneTipoComprobante`$$
+CREATE PROCEDURE `sp_getOneTipoComprobante`(IN p_id INT)
+BEGIN
+    SELECT id, codigo, nombre, estado FROM tipos_comprobante WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_createTipoComprobante`$$
+CREATE PROCEDURE `sp_createTipoComprobante`(IN p_codigo VARCHAR(2), IN p_nombre VARCHAR(50))
+BEGIN
+    INSERT INTO tipos_comprobante (codigo, nombre) VALUES (p_codigo, p_nombre);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_updateTipoComprobante`$$
+CREATE PROCEDURE `sp_updateTipoComprobante`(IN p_id INT, IN p_codigo VARCHAR(2), IN p_nombre VARCHAR(50), IN p_estado BOOLEAN)
+BEGIN
+    UPDATE tipos_comprobante SET codigo = p_codigo, nombre = p_nombre, estado = p_estado WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_deleteTipoComprobante`$$
+CREATE PROCEDURE `sp_deleteTipoComprobante`(IN p_id INT)
+BEGIN
+    UPDATE tipos_comprobante SET estado = 0 WHERE id = p_id;
+END$$
+
+-- -----------------------------------------------------
+-- Update Stored Procedures for `pedidos`
+-- -----------------------------------------------------
+DROP PROCEDURE IF EXISTS sp_getOrderDetail$$
+CREATE PROCEDURE sp_getOrderDetail(IN p_id_pedido INT)
+BEGIN
+    SELECT
+        p.id,
+        p.id_mesa,
+        m.numero_mesa,
+        p.id_usuario_mozo,
+        u.nombre_completo AS nombre_mozo,
+        p.estado,
+        p.total,
+        p.fecha_creacion,
+        p.fecha_actualizacion,
+        p.id_cliente,
+        c.nombres_apellidos AS nombre_cliente,
+        c.numero_documento AS ruc_cliente,
+        c.direccion AS direccion_cliente,
+        p.id_tipo_comprobante
+    FROM pedidos p
+    LEFT JOIN mesas m ON p.id_mesa = m.id
+    LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id
+    LEFT JOIN clientes c ON p.id_cliente = c.id
+    WHERE p.id = p_id_pedido;
+END$$
+
+DROP PROCEDURE IF EXISTS sp_createOrder$$
+CREATE PROCEDURE sp_createOrder(IN p_id_mesa INT, IN p_id_usuario_mozo INT, IN p_items_json JSON, IN p_estado VARCHAR(50), IN p_id_cliente INT, IN p_id_tipo_comprobante INT)
+BEGIN
+    DECLARE v_id_pedido INT;
+    DECLARE v_total_calculado DECIMAL(10, 2) DEFAULT 0;
+    DECLARE v_item JSON;
+    DECLARE v_id_producto INT;
+    DECLARE v_cantidad INT;
+    DECLARE v_precio_unitario DECIMAL(10, 2);
+    DECLARE i INT DEFAULT 0;
+    START TRANSACTION;
+    INSERT INTO pedidos (id_mesa, id_usuario_mozo, total, estado, id_cliente, id_tipo_comprobante) VALUES (p_id_mesa, p_id_usuario_mozo, 0, p_estado, p_id_cliente, p_id_tipo_comprobante);
+    SET v_id_pedido = LAST_INSERT_ID();
+    WHILE i < JSON_LENGTH(p_items_json) DO
+        SET v_item = JSON_EXTRACT(p_items_json, CONCAT('$[', i, ']'));
+        SET v_id_producto = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.id'));
+        SET v_cantidad = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.cantidad'));
+        SELECT precio INTO v_precio_unitario FROM productos WHERE id = v_id_producto;
+        INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario) VALUES (v_id_pedido, v_id_producto, v_cantidad, v_precio_unitario);
+        SET v_total_calculado = v_total_calculado + (v_cantidad * v_precio_unitario);
+        SET i = i + 1;
+    END WHILE;
+    UPDATE pedidos SET total = v_total_calculado WHERE id = v_id_pedido;
+    COMMIT;
+    SELECT v_id_pedido as id;
+END$$
+
+DROP PROCEDURE IF EXISTS sp_updateOrder$$
+CREATE PROCEDURE sp_updateOrder(IN p_id_pedido INT, IN p_id_mesa INT, IN p_id_usuario_mozo INT, IN p_estado VARCHAR(50), IN p_items_json JSON, IN p_id_cliente INT, IN p_id_tipo_comprobante INT)
+BEGIN
+    DECLARE v_total_calculado DECIMAL(10, 2) DEFAULT 0;
+    DECLARE v_item JSON;
+    DECLARE v_id_producto INT;
+    DECLARE v_cantidad INT;
+    DECLARE v_precio_unitario DECIMAL(10, 2);
+    DECLARE i INT DEFAULT 0;
+    START TRANSACTION;
+    DELETE FROM detalle_pedidos WHERE id_pedido = p_id_pedido;
+    WHILE i < JSON_LENGTH(p_items_json) DO
+        SET v_item = JSON_EXTRACT(p_items_json, CONCAT('$[', i, ']'));
+        SET v_id_producto = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.id'));
+        SET v_cantidad = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.cantidad'));
+        SELECT precio INTO v_precio_unitario FROM productos WHERE id = v_id_producto;
+        INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario)
+        VALUES (p_id_pedido, v_id_producto, v_cantidad, v_precio_unitario);
+        SET v_total_calculado = v_total_calculado + (v_cantidad * v_precio_unitario);
+        SET i = i + 1;
+    END WHILE;
+    UPDATE pedidos SET id_mesa = p_id_mesa, id_usuario_mozo = p_id_usuario_mozo, estado = p_estado, total = v_total_calculado, id_cliente = p_id_cliente, id_tipo_comprobante = p_id_tipo_comprobante, fecha_actualizacion = CURRENT_TIMESTAMP WHERE id = p_id_pedido;
+    COMMIT;
+END$$
+
+DELIMITER ;

--- a/backend/migrations/20240921_create_identity_document_types.sql
+++ b/backend/migrations/20240921_create_identity_document_types.sql
@@ -1,0 +1,65 @@
+-- Migration script for creating the tipo_documento_identidad table and stored procedures
+
+-- -----------------------------------------------------
+-- Table `tipo_documento_identidad`
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS `tipo_documento_identidad`;
+
+CREATE TABLE `tipo_documento_identidad` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `codigo` VARCHAR(2) NOT NULL,
+  `nombre` VARCHAR(100) NOT NULL,
+  `descripcion` TEXT NULL,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `codigo_UNIQUE` (`codigo` ASC)
+) ENGINE = InnoDB;
+
+-- -----------------------------------------------------
+-- Initial data for `tipo_documento_identidad`
+-- -----------------------------------------------------
+INSERT INTO `tipo_documento_identidad` (`codigo`, `nombre`, `descripcion`) VALUES
+('0', 'DOC.TRIB.NO.DOM.SIN.RUC', 'Documento Tributario para no domiciliado sin RUC'),
+('1', 'DNI', 'Documento Nacional de Identidad'),
+('4', 'CARNET.EXT', 'Carnet de Extranjería'),
+('6', 'RUC', 'Registro Único de Contribuyentes'),
+('7', 'PASAPORTE', 'Pasaporte'),
+('A', 'CED.DIP.IDENT.', 'Cédula Diplomática de Identidad');
+
+-- -----------------------------------------------------
+-- Stored Procedures for `tipo_documento_identidad`
+-- -----------------------------------------------------
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `sp_getAllIdentityDocumentTypes`$$
+CREATE PROCEDURE `sp_getAllIdentityDocumentTypes`()
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado FROM tipo_documento_identidad WHERE estado = 1;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_getOneIdentityDocumentType`$$
+CREATE PROCEDURE `sp_getOneIdentityDocumentType`(IN p_id INT)
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado FROM tipo_documento_identidad WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_createIdentityDocumentType`$$
+CREATE PROCEDURE `sp_createIdentityDocumentType`(IN p_codigo VARCHAR(2), IN p_nombre VARCHAR(100), IN p_descripcion TEXT)
+BEGIN
+    INSERT INTO tipo_documento_identidad (codigo, nombre, descripcion) VALUES (p_codigo, p_nombre, p_descripcion);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_updateIdentityDocumentType`$$
+CREATE PROCEDURE `sp_updateIdentityDocumentType`(IN p_id INT, IN p_codigo VARCHAR(2), IN p_nombre VARCHAR(100), IN p_descripcion TEXT, IN p_estado BOOLEAN)
+BEGIN
+    UPDATE tipo_documento_identidad SET codigo = p_codigo, nombre = p_nombre, descripcion = p_descripcion, estado = p_estado WHERE id = p_id;
+END$$
+
+DROP PROCEDURE IF EXISTS `sp_deleteIdentityDocumentType`$$
+CREATE PROCEDURE `sp_deleteIdentityDocumentType`(IN p_id INT)
+BEGIN
+    UPDATE tipo_documento_identidad SET estado = 0 WHERE id = p_id;
+END$$
+
+DELIMITER ;

--- a/backend/migrations/20240922_create_clientes_table.sql
+++ b/backend/migrations/20240922_create_clientes_table.sql
@@ -16,7 +16,7 @@ CREATE TABLE `clientes` (
   `telefono` VARCHAR(20) NULL,
   `estado` ENUM('Activado', 'Desactivado') NOT NULL DEFAULT 'Activado',
   PRIMARY KEY (`id`),
-  UNIQUE INDEX `numero_documento_UNIQUE` (`numero_documento` ASC),
+  UNIQUE INDEX `documento_UNIQUE` (`id_tipo_documento_identidad` ASC, `numero_documento` ASC),
   CONSTRAINT `fk_clientes_tipo_documento_identidad`
     FOREIGN KEY (`id_tipo_documento_identidad`)
     REFERENCES `tipo_documento_identidad` (`id`)
@@ -137,6 +137,32 @@ DROP PROCEDURE IF EXISTS `sp_deleteCliente`$$
 CREATE PROCEDURE `sp_deleteCliente`(IN p_id INT)
 BEGIN
     UPDATE clientes SET estado = 'Desactivado' WHERE id = p_id;
+END$$
+
+-- Search clients
+DROP PROCEDURE IF EXISTS `sp_searchClientes`$$
+CREATE PROCEDURE `sp_searchClientes`(IN p_search_term VARCHAR(200))
+BEGIN
+    SELECT
+        c.id,
+        c.id_tipo_documento_identidad,
+        tdi.nombre as tipo_documento_nombre,
+        c.numero_documento,
+        c.nombres_apellidos,
+        c.direccion,
+        c.codigo_ubigeo,
+        c.email,
+        c.telefono,
+        c.estado
+    FROM
+        clientes c
+    JOIN
+        tipo_documento_identidad tdi ON c.id_tipo_documento_identidad = tdi.id
+    WHERE
+        (c.nombres_apellidos LIKE p_search_term OR c.numero_documento LIKE p_search_term)
+        AND c.estado = 'Activado'
+    ORDER BY
+        c.nombres_apellidos;
 END$$
 
 DELIMITER ;

--- a/backend/models/Cliente.php
+++ b/backend/models/Cliente.php
@@ -8,6 +8,15 @@ class Cliente {
         $this->conn = Database::getInstance();
     }
 
+    public function search($search_term) {
+        $query = "CALL sp_searchClientes(:search_term)";
+        $stmt = $this->conn->prepare($query);
+        $search_term = "%{$search_term}%";
+        $stmt->bindParam(':search_term', $search_term);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readAll() {
         $query = "CALL sp_getAllClientes()";
         $stmt = $this->conn->prepare($query);

--- a/backend/models/Order.php
+++ b/backend/models/Order.php
@@ -52,22 +52,24 @@ class Order {
         return $order_details;
     }
 
-    public function create($id_mesa, $id_usuario_mozo, $items, $estado = 'recibido') {
-        $query = "CALL sp_createOrder(:id_mesa, :id_usuario_mozo, :items_json, :estado)";
+    public function create($id_mesa, $id_usuario_mozo, $items, $estado = 'recibido', $id_cliente = null, $id_tipo_comprobante = null) {
+        $query = "CALL sp_createOrder(:id_mesa, :id_usuario_mozo, :items_json, :estado, :id_cliente, :id_tipo_comprobante)";
         $stmt = $this->conn->prepare($query);
         $items_json = json_encode($items);
         $stmt->bindParam(':id_mesa', $id_mesa);
         $stmt->bindParam(':id_usuario_mozo', $id_usuario_mozo);
         $stmt->bindParam(':items_json', $items_json);
         $stmt->bindParam(':estado', $estado);
+        $stmt->bindParam(':id_cliente', $id_cliente);
+        $stmt->bindParam(':id_tipo_comprobante', $id_tipo_comprobante);
         if ($stmt->execute()) {
             return $stmt;
         }
         return false;
     }
 
-    public function update($id, $id_mesa, $id_usuario_mozo, $status, $items) {
-        $query = "CALL sp_updateOrder(:id, :id_mesa, :id_usuario_mozo, :status, :items_json)";
+    public function update($id, $id_mesa, $id_usuario_mozo, $status, $items, $id_cliente = null, $id_tipo_comprobante = null) {
+        $query = "CALL sp_updateOrder(:id, :id_mesa, :id_usuario_mozo, :status, :items_json, :id_cliente, :id_tipo_comprobante)";
         $stmt = $this->conn->prepare($query);
         $items_json = json_encode($items);
         $stmt->bindParam(':id', $id);
@@ -75,6 +77,8 @@ class Order {
         $stmt->bindParam(':id_usuario_mozo', $id_usuario_mozo);
         $stmt->bindParam(':status', $status);
         $stmt->bindParam(':items_json', $items_json);
+        $stmt->bindParam(':id_cliente', $id_cliente);
+        $stmt->bindParam(':id_tipo_comprobante', $id_tipo_comprobante);
         return $stmt->execute();
     }
 }

--- a/backend/models/SaleDocumentType.php
+++ b/backend/models/SaleDocumentType.php
@@ -9,45 +9,43 @@ class SaleDocumentType {
     }
 
     public function readAll() {
-        $query = "CALL sp_getAllSaleDocumentTypes()";
+        $query = "CALL sp_getAllTiposComprobante()";
         $stmt = $this->conn->prepare($query);
         $stmt->execute();
         return $stmt;
     }
 
     public function readOne($id) {
-        $query = "CALL sp_getOneSaleDocumentType(:id)";
+        $query = "CALL sp_getOneTipoComprobante(:id)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':id', $id);
         $stmt->execute();
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 
-    public function create($codigo, $nombre, $descripcion) {
-        $query = "CALL sp_createSaleDocumentType(:codigo, :nombre, :descripcion)";
+    public function create($codigo, $nombre) {
+        $query = "CALL sp_createTipoComprobante(:codigo, :nombre)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':codigo', $codigo);
         $stmt->bindParam(':nombre', $nombre);
-        $stmt->bindParam(':descripcion', $descripcion);
         if ($stmt->execute()) {
             return $stmt;
         }
         return false;
     }
 
-    public function update($id, $codigo, $nombre, $descripcion, $estado) {
-        $query = "CALL sp_updateSaleDocumentType(:id, :codigo, :nombre, :descripcion, :estado)";
+    public function update($id, $codigo, $nombre, $estado) {
+        $query = "CALL sp_updateTipoComprobante(:id, :codigo, :nombre, :estado)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':id', $id);
         $stmt->bindParam(':codigo', $codigo);
         $stmt->bindParam(':nombre', $nombre);
-        $stmt->bindParam(':descripcion', $descripcion);
         $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
         return $stmt->execute();
     }
 
     public function delete($id) {
-        $query = "CALL sp_deleteSaleDocumentType(:id)";
+        $query = "CALL sp_deleteTipoComprobante(:id)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':id', $id);
         return $stmt->execute();

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -187,7 +187,34 @@ if ($is_pago_view) {
                                 </div>
                             </div>
                             <div id="tab-client" class="tab-pane">
-                                <!-- Contenido del tab de cliente va aquí -->
+                                <div class="form-group">
+                                    <label for="id_tipo_comprobante">Tipo de Comprobante</label>
+                                    <select id="id_tipo_comprobante" name="id_tipo_comprobante">
+                                        <option value="">Seleccione...</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label for="cliente_search">Buscar Cliente (Nombre o RUC)</label>
+                                    <input type="text" id="cliente_search" placeholder="Escriba para buscar...">
+                                    <div id="cliente_search_results"></div>
+                                </div>
+                                <input type="hidden" id="id_cliente" name="id_cliente" value="<?php echo htmlspecialchars($order_data['id_cliente'] ?? ''); ?>">
+
+                                <div class="form-group">
+                                    <label for="cliente_nombre">Nombre del Cliente</label>
+                                    <input type="text" id="cliente_nombre" name="cliente_nombre" value="<?php echo htmlspecialchars($order_data['nombre_cliente'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group">
+                                    <label for="cliente_ruc">RUC</label>
+                                    <input type="text" id="cliente_ruc" name="cliente_ruc" value="<?php echo htmlspecialchars($order_data['ruc_cliente'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group">
+                                    <label for="cliente_direccion">Dirección</label>
+                                    <input type="text" id="cliente_direccion" name="cliente_direccion" value="<?php echo htmlspecialchars($order_data['direccion_cliente'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group">
+                                    <button type="button" id="btn-crear-cliente" class="btn">Crear Cliente</button>
+                                </div>
                             </div>
                         </div>
 
@@ -418,6 +445,29 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     orderForm.addEventListener('submit', function(e) {
+        // Validation logic
+        const tipoComprobanteSelect = document.getElementById('id_tipo_comprobante');
+        const selectedComprobante = tipoComprobanteSelect.options[tipoComprobanteSelect.selectedIndex];
+
+        if (selectedComprobante && selectedComprobante.textContent === 'Factura') {
+            const idCliente = document.getElementById('id_cliente').value;
+            const clienteNombre = document.getElementById('cliente_nombre').value;
+            const clienteDireccion = document.getElementById('cliente_direccion').value;
+
+            if (!idCliente || !clienteNombre || !clienteDireccion) {
+                e.preventDefault();
+                alert('Para emitir una Factura, debe seleccionar un cliente con RUC, nombre y dirección.');
+                return;
+            }
+        } else {
+            const clienteNombre = document.getElementById('cliente_nombre').value;
+            if (!clienteNombre) {
+                e.preventDefault();
+                alert('El campo nombre del cliente es obligatorio.');
+                return;
+            }
+        }
+
         const itemsInput = document.createElement('input');
         itemsInput.type = 'hidden';
         itemsInput.name = 'items';
@@ -452,5 +502,248 @@ document.addEventListener('DOMContentLoaded', function() {
         const tabId = targetButton.dataset.tab;
         document.getElementById('tab-' + tabId).classList.add('active');
     });
+
+    // Client tab logic
+    const tipoComprobanteSelect = document.getElementById('id_tipo_comprobante');
+    const clienteSearchInput = document.getElementById('cliente_search');
+    const clienteSearchResults = document.getElementById('cliente_search_results');
+    const idClienteInput = document.getElementById('id_cliente');
+    const clienteNombreInput = document.getElementById('cliente_nombre');
+    const clienteRucInput = document.getElementById('cliente_ruc');
+    const clienteDireccionInput = document.getElementById('cliente_direccion');
+
+    async function loadTiposComprobante() {
+        try {
+            const response = await fetch(`${apiBaseUrl}tipos_documentos.php`);
+            const data = await response.json();
+            if (data.records) {
+                data.records.forEach(tipo => {
+                    const option = document.createElement('option');
+                    option.value = tipo.id;
+                    option.textContent = tipo.nombre;
+                    if (isEditing && initialOrderData && initialOrderData.id_tipo_comprobante == tipo.id) {
+                        option.selected = true;
+                    }
+                    tipoComprobanteSelect.appendChild(option);
+                });
+            }
+        } catch (error) {
+            console.error('Error loading document types:', error);
+        }
+    }
+
+    clienteSearchInput.addEventListener('keyup', async function() {
+        const query = this.value.trim();
+        if (query.length < 2) {
+            clienteSearchResults.innerHTML = '';
+            return;
+        }
+
+        try {
+            const response = await fetch(`${apiBaseUrl}clientes.php?search=${encodeURIComponent(query)}`);
+            const data = await response.json();
+            clienteSearchResults.innerHTML = '';
+            if (data.records) {
+                data.records.forEach(cliente => {
+                    const div = document.createElement('div');
+                    div.textContent = `${cliente.nombres_apellidos} - ${cliente.numero_documento}`;
+                    div.classList.add('search-result-item');
+                    div.addEventListener('click', () => {
+                        selectCliente(cliente);
+                        clienteSearchResults.innerHTML = '';
+                        clienteSearchInput.value = '';
+                    });
+                    clienteSearchResults.appendChild(div);
+                });
+            }
+        } catch (error) {
+            console.error('Error searching clients:', error);
+        }
+    });
+
+    function selectCliente(cliente) {
+        idClienteInput.value = cliente.id;
+        clienteNombreInput.value = cliente.nombres_apellidos;
+        clienteRucInput.value = cliente.numero_documento;
+        clienteDireccionInput.value = cliente.direccion;
+    }
+
+    // Load initial data
+    loadTiposComprobante();
+
+    if (isEditing && initialOrderData) {
+        if (initialOrderData.id_cliente) {
+            // The customer data is already loaded in the inputs via PHP
+        }
+    }
+    const btnCrearCliente = document.getElementById('btn-crear-cliente');
+    const modalCrearCliente = document.getElementById('modal-crear-cliente');
+    const closeBtn = document.querySelector('.close-btn');
+
+    btnCrearCliente.addEventListener('click', () => {
+        modalCrearCliente.style.display = 'block';
+    });
+
+    closeBtn.addEventListener('click', () => {
+        modalCrearCliente.style.display = 'none';
+    });
+
+    window.addEventListener('click', (e) => {
+        if (e.target == modalCrearCliente) {
+            modalCrearCliente.style.display = 'none';
+        }
+    });
+
+    // Modal logic
+    const modalForm = document.getElementById('form-crear-cliente');
+    const modalTipoDocumentoSelect = document.getElementById('modal_id_tipo_documento_identidad');
+    const modalSunatBtn = document.getElementById('modal-sunat-btn');
+    const modalNumeroDocumentoInput = document.getElementById('modal_numero_documento');
+    const modalNombresInput = document.getElementById('modal_nombres_apellidos');
+    const modalDireccionInput = document.getElementById('modal_direccion');
+    const modalUbigeoInput = document.getElementById('modal_codigo_ubigeo');
+
+    async function loadDocumentTypesForModal() {
+        try {
+            const response = await fetch(`${apiBaseUrl}tipo_documento_identidad.php`);
+            const data = await response.json();
+            if (data.records) {
+                data.records.forEach(type => {
+                    const option = document.createElement('option');
+                    option.value = type.id;
+                    option.dataset.codigo = type.codigo;
+                    option.textContent = type.nombre;
+                    modalTipoDocumentoSelect.appendChild(option);
+                });
+            }
+        } catch (error) {
+            console.error('Error loading document types for modal:', error);
+        }
+    }
+
+    function toggleModalSunatButton() {
+        const selectedOption = modalTipoDocumentoSelect.options[modalTipoDocumentoSelect.selectedIndex];
+        const docCode = selectedOption ? selectedOption.getAttribute('data-codigo') : null;
+        const validDocumentCodes = ['1', '6']; // DNI and RUC
+        if (docCode && validDocumentCodes.includes(docCode)) {
+            modalSunatBtn.style.display = 'inline-block';
+        } else {
+            modalSunatBtn.style.display = 'none';
+        }
+    }
+
+    modalTipoDocumentoSelect.addEventListener('change', toggleModalSunatButton);
+    loadDocumentTypesForModal();
+    toggleModalSunatButton();
+
+    modalSunatBtn.addEventListener('click', async () => {
+        const selectedOption = modalTipoDocumentoSelect.options[modalTipoDocumentoSelect.selectedIndex];
+        const docCode = selectedOption ? selectedOption.getAttribute('data-codigo') : null;
+        const docNumber = modalNumeroDocumentoInput.value.trim();
+
+        if (!docCode || !docNumber) {
+            alert('Por favor, seleccione un tipo de documento y ingrese un número.');
+            return;
+        }
+
+        let queryType = (docCode === '1') ? 'dni' : 'ruc';
+        modalSunatBtn.textContent = 'Buscando...';
+        modalSunatBtn.disabled = true;
+
+        try {
+            const response = await fetch(`consulta_api_externa.php?tipo=${queryType}&numero=${docNumber}`);
+            const data = await response.json();
+            if (data.error) throw new Error(data.error);
+            modalNombresInput.value = data.nombre || '';
+            modalDireccionInput.value = data.direccion || '';
+            modalUbigeoInput.value = data.ubigeo || '';
+        } catch (error) {
+            alert('Error al consultar: ' + error.message);
+        } finally {
+            modalSunatBtn.textContent = 'Sunat';
+            modalSunatBtn.disabled = false;
+        }
+    });
+
+    modalForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(modalForm);
+        const clienteData = Object.fromEntries(formData.entries());
+
+        try {
+            const response = await fetch(`${apiBaseUrl}clientes.php`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(clienteData)
+            });
+
+            const result = await response.json();
+
+            if (response.ok) {
+                alert('Cliente creado exitosamente.');
+                modalCrearCliente.style.display = 'none';
+                modalForm.reset();
+
+                // Select the new client
+                selectCliente({
+                    id: result.id,
+                    nombres_apellidos: clienteData.nombres_apellidos,
+                    numero_documento: clienteData.numero_documento,
+                    direccion: clienteData.direccion
+                });
+
+            } else {
+                throw new Error(result.message || 'Error al crear el cliente.');
+            }
+        } catch (error) {
+            alert('Error: ' + error.message);
+        }
+    });
 });
 </script>
+
+<!-- Modal para Crear Cliente -->
+<div id="modal-crear-cliente" class="modal">
+    <div class="modal-content">
+        <span class="close-btn">&times;</span>
+        <h2>Crear Nuevo Cliente</h2>
+        <form id="form-crear-cliente">
+            <div class="form-group">
+                <label for="modal_id_tipo_documento_identidad">Tipo de Documento</label>
+                <select id="modal_id_tipo_documento_identidad" name="id_tipo_documento_identidad" required>
+                    <option value="">Seleccione...</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="modal_numero_documento">N° de Documento</label>
+                <div style="display: flex; gap: 10px;">
+                    <input type="text" id="modal_numero_documento" name="numero_documento" required style="flex-grow: 1;">
+                    <button type="button" class="btn" id="modal-sunat-btn" style="flex-shrink: 0; display: none;">Sunat</button>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="modal_nombres_apellidos">Nombres y Apellidos</label>
+                <input type="text" id="modal_nombres_apellidos" name="nombres_apellidos" required>
+            </div>
+            <div class="form-group">
+                <label for="modal_direccion">Dirección</label>
+                <input type="text" id="modal_direccion" name="direccion">
+            </div>
+            <div class="form-group">
+                <label for="modal_codigo_ubigeo">Código de Ubigeo</label>
+                <input type="text" id="modal_codigo_ubigeo" name="codigo_ubigeo">
+            </div>
+            <div class="form-group">
+                <label for="modal_email">Email</label>
+                <input type="email" id="modal_email" name="email">
+            </div>
+            <div class="form-group">
+                <label for="modal_telefono">Teléfono</label>
+                <input type="text" id="modal_telefono" name="telefono">
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="btn">Guardar Cliente</button>
+            </div>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
This commit introduces a new "Clientes" (Customers) tab to the order creation and editing page (`pedido_form.php`).

Features:
- A dropdown to select the document type (Boleta/Factura).
- A customer search input to find existing customers by name or RUC.
- A "Crear Cliente" (Create Customer) button that opens a modal for quick customer creation.
- The modal includes a "Sunat" button to fetch customer data from an external API.
- Validation is implemented to require a customer for "Factura" documents.
- The order now stores the `id_cliente` and `id_tipo_comprobante`.

Database changes:
- Added `id_cliente` and `id_tipo_comprobante` to the `pedidos` table.
- Created a `tipos_comprobante` table.
- Created a `tipo_documento_identidad` table.
- Updated stored procedures for orders and customers.