### PR TITLE
feat(pedidos): Save client and voucher type in order

### DIFF
--- a/frontend_web/pedido_handler.php
+++ b/frontend_web/pedido_handler.php
@@ -45,7 +45,9 @@ $api_data = [
     'id_mesa' => $id_mesa,
     'id_usuario_mozo' => $id_usuario_mozo,
     'estado' => $estado,
-    'items' => $items
+    'items' => $items,
+    'id_cliente' => $_POST['id_cliente'] ?? null,
+    'id_tipo_documento_venta' => $_POST['id_tipo_documento_venta'] ?? null
 ];
 
 // Incluir configuración de la API


### PR DESCRIPTION
This commit enhances the order creation/editing process by ensuring that the selected client and voucher type are saved with the order.

- Modifies `frontend_web/pedido_handler.php` to include `id_cliente` and `id_tipo_documento_venta` in the data sent to the backend API when creating or updating an order.
- This ensures that when an order is updated, the client information and voucher type selected in the 'Clientes' tab are correctly persisted.