### PR TITLE
fix(pedidos): Load client document type and ubigeo in order form

### DIFF
--- a/backend/migrations/20240721_feature_customer_orders_final.sql
+++ b/backend/migrations/20240721_feature_customer_orders_final.sql
@@ -92,7 +92,7 @@ CREATE PROCEDURE sp_getOrderDetail(IN p_id_pedido INT)
 BEGIN
     SELECT
         p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion, p.fecha_actualizacion,
-        p.id_cliente, c.nombres_apellidos AS nombre_cliente, c.numero_documento AS ruc_cliente, c.direccion AS direccion_cliente,
+        p.id_cliente, c.nombres_apellidos AS nombre_cliente, c.numero_documento AS ruc_cliente, c.direccion AS direccion_cliente, c.codigo_ubigeo, c.id_tipo_documento_identidad AS id_tipo_documento_identidad_cliente,
         p.id_tipo_documento_venta
     FROM pedidos p
     LEFT JOIN mesas m ON p.id_mesa = m.id


### PR DESCRIPTION
This commit fixes a bug where the client's document type and ubigeo code were not being displayed when editing an order.

- Modifies the `sp_getOrderDetail` stored procedure to include `id_tipo_documento_identidad` and `codigo_ubigeo` from the `clientes` table in the result set.
- The frontend `pedido_form.php` already had the logic to populate these fields, but was not receiving the data from the backend. This change ensures the data is now available and displayed correctly.