### PR TITLE
fix(pedidos): Load all client data on order edit

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -713,21 +713,27 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    loadSaleDocumentTypes();
-    loadIdentityDocumentTypes(clienteTipoDocIdentidadSelect);
+    async function initializeForm() {
+        await Promise.all([
+            loadSaleDocumentTypes(),
+            loadIdentityDocumentTypes(clienteTipoDocIdentidadSelect)
+        ]);
 
-    if (isEditing && initialOrderData && initialOrderData.id_cliente) {
-        selectCliente({
-            id: initialOrderData.id_cliente,
-            nombres_apellidos: initialOrderData.nombre_cliente,
-            id_tipo_documento_identidad: initialOrderData.id_tipo_documento_identidad_cliente,
-            numero_documento: initialOrderData.ruc_cliente,
-            direccion: initialOrderData.direccion_cliente,
-            codigo_ubigeo: initialOrderData.codigo_ubigeo
-        });
-    } else {
-        clearClienteSelection();
+        if (isEditing && initialOrderData && initialOrderData.id_cliente) {
+            selectCliente({
+                id: initialOrderData.id_cliente,
+                nombres_apellidos: initialOrderData.nombre_cliente,
+                id_tipo_documento_identidad: initialOrderData.id_tipo_documento_identidad_cliente,
+                numero_documento: initialOrderData.ruc_cliente,
+                direccion: initialOrderData.direccion_cliente,
+                codigo_ubigeo: initialOrderData.codigo_ubigeo
+            });
+        } else {
+            clearClienteSelection();
+        }
     }
+
+    initializeForm();
 
 });
 </script>


### PR DESCRIPTION
This commit fixes a bug where the client's 'Tipo de Documento' and 'Ubigeo' were not being displayed when editing an order.

- Modifies the `sp_getOrderDetail` stored procedure to include the client's `id_tipo_documento_identidad` and `codigo_ubigeo` in the data fetched for an order.
- Updates the JavaScript in `pedido_form.php` to correctly handle the asynchronous loading of document types, ensuring the client's document type is selected correctly when the form is populated.
- Modifies `pedido_handler.php` to ensure the `id_cliente` and `id_tipo_documento_venta` are correctly passed when an order is updated.
- Refactors the 'Clientes' tab in `pedido_form.php` to integrate the client form directly, removing the need for a separate modal and improving the user experience.