### PR TITLE
feat(clientes): Implement hard delete for clients

### DIFF
--- a/backend/migrations/20250922_create_clientes_table.sql
+++ b/backend/migrations/20250922_create_clientes_table.sql
@@ -133,10 +133,11 @@ BEGIN
 END$$
 
 -- Delete a client (logical delete)
+-- Delete a client (hard delete)
 DROP PROCEDURE IF EXISTS `sp_deleteCliente`$$
 CREATE PROCEDURE `sp_deleteCliente`(IN p_id INT)
 BEGIN
-    UPDATE clientes SET estado = 'Desactivado' WHERE id = p_id;
+    DELETE FROM clientes WHERE id = p_id;
 END$$
 
 DELIMITER ;

--- a/frontend_web/clientes.php
+++ b/frontend_web/clientes.php
@@ -73,7 +73,7 @@ $clientes_data = getClientes();
                                     </td>
                                     <td class="actions-cell">
                                         <a href="cliente_form.php?id=<?php echo $cliente['id']; ?>" class="btn btn-edit">Editar</a>
-                                        <a href="cliente_delete_handler.php?id=<?php echo $cliente['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro de que quieres desactivar este cliente?');">Eliminar</a>
+                                        <a href="cliente_delete_handler.php?id=<?php echo $cliente['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro de que quieres eliminar permanentemente este cliente? Esta acción no se puede deshacer.');">Eliminar</a>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>


### PR DESCRIPTION
This commit changes the delete functionality for clients from a soft delete (deactivating the record) to a hard delete (permanently removing the record from the database), as requested by the user.

- Modifies the `sp_deleteCliente` stored procedure to use a `DELETE` statement instead of an `UPDATE` statement.
- Updates the confirmation message in the `clientes.php` page to warn the user that the deletion is permanent and cannot be undone.