### PR TITLE
fix(tipos_documentos): Fix undefined index on edit form

### DIFF
--- a/backend/api/v1/tipos_documentos.php
+++ b/backend/api/v1/tipos_documentos.php
@@ -8,22 +8,30 @@ include_once __DIR__ . '/../../models/SaleDocumentType.php';
 
 $saleDocumentType = new SaleDocumentType();
 
-$stmt = $saleDocumentType->readAll();
-$num = $stmt->rowCount();
-
-if ($num > 0) {
-    $types_arr = ["records" => []];
-    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-        // The SP only returns active records, but we ensure the 'estado' key exists for consistency if needed later.
-        if (!isset($row['estado'])) {
-            $row['estado'] = true;
-        }
-        array_push($types_arr["records"], $row);
+if (!empty($_GET["id"])) {
+    $type_id = intval($_GET["id"]);
+    $type_data = $saleDocumentType->readOne($type_id);
+    if ($type_data) {
+        http_response_code(200);
+        echo json_encode($type_data);
+    } else {
+        http_response_code(404);
+        echo json_encode(["message" => "Tipo de documento no encontrado."]);
     }
-    http_response_code(200);
-    echo json_encode($types_arr);
 } else {
-    http_response_code(200);
-    echo json_encode(["records" => []]);
+    $stmt = $saleDocumentType->readAll();
+    $num = $stmt->rowCount();
+
+    if ($num > 0) {
+        $types_arr = ["records" => []];
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            array_push($types_arr["records"], $row);
+        }
+        http_response_code(200);
+        echo json_encode($types_arr);
+    } else {
+        http_response_code(200);
+        echo json_encode(["records" => []]);
+    }
 }
 ?>

--- a/backend/migrations/20240721_feature_customer_orders_final.sql
+++ b/backend/migrations/20240721_feature_customer_orders_final.sql
@@ -49,6 +49,14 @@ BEGIN
     SELECT id, codigo, nombre, descripcion, estado FROM tipo_documento_venta;
 END$$
 
+DROP PROCEDURE IF EXISTS `sp_getOneSaleDocumentType`$$
+CREATE PROCEDURE `sp_getOneSaleDocumentType`(IN p_id INT)
+BEGIN
+    SELECT id, codigo, nombre, descripcion, estado
+    FROM tipo_documento_venta
+    WHERE id = p_id;
+END$$
+
 DELIMITER ;
 
 -- -----------------------------------------------------

--- a/frontend_web/tipos_documentos_form.php
+++ b/frontend_web/tipos_documentos_form.php
@@ -35,25 +35,25 @@ include_once 'templates/header.php';
             </div>
             <div class="form-container">
                 <form action="tipos_documentos_handler.php" method="POST">
-                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($type_data['id']); ?>">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($type_data['id'] ?? ''); ?>">
                     <div class="form-group">
                         <label for="codigo">Código SUNAT</label>
-                        <input type="text" id="codigo" name="codigo" value="<?php echo htmlspecialchars($type_data['codigo']); ?>" required>
+                        <input type="text" id="codigo" name="codigo" value="<?php echo htmlspecialchars($type_data['codigo'] ?? ''); ?>" required>
                     </div>
                     <div class="form-group">
                         <label for="nombre">Nombre</label>
-                        <input type="text" id="nombre" name="nombre" value="<?php echo htmlspecialchars($type_data['nombre']); ?>" required>
+                        <input type="text" id="nombre" name="nombre" value="<?php echo htmlspecialchars($type_data['nombre'] ?? ''); ?>" required>
                     </div>
                     <div class="form-group">
                         <label for="descripcion">Descripción</label>
-                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($type_data['descripcion']); ?></textarea>
+                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($type_data['descripcion'] ?? ''); ?></textarea>
                     </div>
                     <?php if ($is_editing): ?>
                     <div class="form-group">
                         <label for="estado">Estado</label>
                         <select id="estado" name="estado">
-                            <option value="1" <?php echo ($type_data['estado'] == 1) ? 'selected' : ''; ?>>Activo</option>
-                            <option value="0" <?php echo ($type_data['estado'] == 0) ? 'selected' : ''; ?>>Inactivo</option>
+                            <option value="1" <?php echo (($type_data['estado'] ?? 1) == 1) ? 'selected' : ''; ?>>Activo</option>
+                            <option value="0" <?php echo (($type_data['estado'] ?? 1) == 0) ? 'selected' : ''; ?>>Inactivo</option>
                         </select>
                     </div>
                     <?php endif; ?>


### PR DESCRIPTION
This commit fixes a bug where "Undefined index" notices for `codigo`, `nombre`, `descripcion`, and `estado` were displayed when editing a 'Tipo de Documento de Venta'.

- Creates a new stored procedure `sp_getOneSaleDocumentType` to fetch a single document type by its ID.
- Updates the API endpoint `tipos_documentos.php` to handle GET requests with an `id` parameter, calling the new stored procedure.
- Modifies the `tipos_documentos_form.php` to use the null coalescing operator (`??`) when displaying data, making the frontend more robust against missing data.