### PR TITLE
Fix(pedido): Carga correctamente los datos del cliente al editar un p…

### DIFF
--- a/backend/database.sql
+++ b/backend/database.sql
@@ -163,7 +163,33 @@ END$$
 DROP PROCEDURE IF EXISTS sp_getOrderDetail$$
 CREATE PROCEDURE sp_getOrderDetail(IN p_id_pedido INT)
 BEGIN
-    SELECT p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion, p.fecha_actualizacion FROM pedidos p LEFT JOIN mesas m ON p.id_mesa = m.id LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id WHERE p.id = p_id_pedido;
+    SELECT
+        p.id,
+        p.id_mesa,
+        m.numero_mesa,
+        p.id_usuario_mozo,
+        u.nombre_completo AS nombre_mozo,
+        p.estado,
+        p.total,
+        p.fecha_creacion,
+        p.fecha_actualizacion,
+        p.id_cliente,
+        p.id_tipo_documento_venta,
+        c.nombres_apellidos AS nombre_cliente,
+        c.numero_documento AS ruc_cliente,
+        c.id_tipo_documento_identidad AS id_tipo_documento_identidad_cliente,
+        c.direccion AS direccion_cliente,
+        c.codigo_ubigeo
+    FROM
+        pedidos p
+    LEFT JOIN
+        mesas m ON p.id_mesa = m.id
+    LEFT JOIN
+        usuarios u ON p.id_usuario_mozo = u.id
+    LEFT JOIN
+        clientes c ON p.id_cliente = c.id
+    WHERE
+        p.id = p_id_pedido;
 END$$
 
 DROP PROCEDURE IF EXISTS sp_getOrderItems$$


### PR DESCRIPTION
…edido

Este commit soluciona un bug que impedía que los campos 'Tipo de Documento de Identidad' y 'Ubigeo' del cliente se cargaran en el formulario al editar un pedido.

El problema se debía a que el procedimiento almacenado `sp_getOrderDetail` no estaba obteniendo todos los datos necesarios del cliente asociado al pedido.

La solución ha sido:
- Modificar el procedimiento almacenado `sp_getOrderDetail` en `backend/database.sql`.
- Se ha añadido un `LEFT JOIN` con la tabla `clientes`.
- La consulta ahora selecciona y devuelve el `id_tipo_documento_identidad` y el `codigo_ubigeo` del cliente, junto con los demás datos del pedido.

Con este cambio, la API de pedidos (`/pedidos.php?id=...`) ahora proporciona toda la información del cliente, y el formulario de edición la muestra correctamente sin necesidad de cambios en el frontend.