### PR TITLE
feat(pedidos): Filtrar pedidos por estado en diferentes páginas

### DIFF
--- a/backend/database.sql
+++ b/backend/database.sql
@@ -155,9 +155,27 @@ END$$
 
 -- Procedimientos para 'pedidos'
 DROP PROCEDURE IF EXISTS sp_getAllOrders$$
-CREATE PROCEDURE sp_getAllOrders()
+CREATE PROCEDURE sp_getAllOrders(IN p_status VARCHAR(255))
 BEGIN
-    SELECT p.id, p.id_mesa, m.numero_mesa, p.id_usuario_mozo, u.nombre_completo AS nombre_mozo, p.estado, p.total, p.fecha_creacion FROM pedidos p LEFT JOIN mesas m ON p.id_mesa = m.id LEFT JOIN usuarios u ON p.id_usuario_mozo = u.id ORDER BY p.fecha_creacion DESC;
+    SELECT
+        p.id,
+        p.id_mesa,
+        m.numero_mesa,
+        p.id_usuario_mozo,
+        u.nombre_completo AS nombre_mozo,
+        p.estado,
+        p.total,
+        p.fecha_creacion
+    FROM
+        pedidos p
+    LEFT JOIN
+        mesas m ON p.id_mesa = m.id
+    LEFT JOIN
+        usuarios u ON p.id_usuario_mozo = u.id
+    WHERE
+        (p_status IS NULL OR p_status = '' OR FIND_IN_SET(p.estado, p_status))
+    ORDER BY
+        p.fecha_creacion DESC;
 END$$
 
 DROP PROCEDURE IF EXISTS sp_getOrderDetail$$

--- a/backend/models/Order.php
+++ b/backend/models/Order.php
@@ -9,14 +9,14 @@ class Order {
     }
 
     public function readAll() {
-        $query = "CALL sp_getAllOrders()";
+        $query = "CALL sp_getAllOrders(NULL)";
         $stmt = $this->conn->prepare($query);
         $stmt->execute();
         return $stmt;
     }
 
     public function readByStatus($status) {
-        $query = "CALL sp_getOrdersByStatus(:status)";
+        $query = "CALL sp_getAllOrders(:status)";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(':status', $status);
         $stmt->execute();

--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -6,13 +6,12 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
     exit();
 }
 
-$page_title = 'Caja';
+$page_title = 'Pedidos Finalizados';
 include_once 'templates/header.php';
 include_once __DIR__ . '/config.php';
 
 function getCompletedOrders() {
-    // I will modify the API endpoint later to handle this properly
-    $api_url = API_BASE_URL . 'pedidos.php?estado=completado,pagado';
+    $api_url = API_BASE_URL . 'pedidos.php?estado=completado,cancelado';
     $ch = curl_init($api_url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     $response = curl_exec($ch);
@@ -29,7 +28,7 @@ $orders_data = getCompletedOrders();
     <main class="main-content">
         <div class="container">
             <div class="page-header">
-                <h1>Pedidos Completados</h1>
+                <h1>Pedidos Completados y Cancelados</h1>
                 <a href="pedido_form.php?view=caja_create" class="btn">Crear Pedido Nuevo</a>
             </div>
 
@@ -68,7 +67,7 @@ $orders_data = getCompletedOrders();
                         </div>
                     <?php endforeach; ?>
                 <?php else: ?>
-                    <p>No se encontraron pedidos completados.</p>
+                    <p>No se encontraron pedidos completados o cancelados.</p>
                 <?php endif; ?>
             </div>
         </div>

--- a/frontend_web/pedidos.php
+++ b/frontend_web/pedidos.php
@@ -13,8 +13,11 @@ include_once 'templates/header.php';
 include_once __DIR__ . '/config.php';
 
 // Función para obtener los pedidos desde la API
-function getOrders() {
+function getOrders($status = '') {
     $api_url = API_BASE_URL . 'pedidos.php';
+    if (!empty($status)) {
+        $api_url .= '?estado=' . urlencode($status);
+    }
     $ch = curl_init($api_url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     $response = curl_exec($ch);
@@ -22,7 +25,7 @@ function getOrders() {
     return json_decode($response, true);
 }
 
-$orders_data = getOrders();
+$orders_data = getOrders('abierto');
 ?>
 
 <div class="dashboard-container">


### PR DESCRIPTION
Se ha implementado la lógica para mostrar pedidos filtrados por su estado en las páginas 'Historial de Pedidos' y 'Caja', según los requisitos del usuario.

- Se ha modificado el procedimiento almacenado `sp_getAllOrders` para que acepte un parámetro de estado, permitiendo filtrar los resultados.
- El modelo `Order.php` se ha actualizado para pasar el estado al procedimiento almacenado.
- La página 'Historial de Pedidos' (`pedidos.php`) ahora solo muestra los pedidos con estado 'abierto'.
- La página de 'Caja' (`caja.php`) ahora funciona como la vista de 'Pedidos Completados', mostrando los pedidos con estado 'completado' y 'cancelado'. Se han actualizado los títulos y textos en esta página para reflejar su nuevo propósito.