### PR TITLE
fix(pedidos): Mostrar acciones de estado en la vista de pago

### DIFF
--- a/backend/models/Order.php
+++ b/backend/models/Order.php
@@ -52,7 +52,7 @@ class Order {
         return $order_details;
     }
 
-    public function create($id_mesa, $id_usuario_mozo, $items, $estado = 'abierto', $id_cliente = null, $id_tipo_documento_venta = null) {
+    public function create($id_mesa, $id_usuario_mozo, $items, $estado = 'recibido', $id_cliente = null, $id_tipo_documento_venta = null) {
         $query = "CALL sp_createOrder(:id_mesa, :id_usuario_mozo, :items_json, :estado, :id_cliente, :id_tipo_documento_venta)";
         $stmt = $this->conn->prepare($query);
         $items_json = json_encode($items);

--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -28,7 +28,7 @@ $orders_data = getCompletedOrders();
     <main class="main-content">
         <div class="container">
             <div class="page-header">
-                <h1>Caja</h1>
+                <h1>Pedidos Completados y Cancelados</h1>
                 <a href="pedido_form.php?view=caja_create" class="btn">Crear Pedido Nuevo</a>
             </div>
 

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -127,7 +127,7 @@ if ($is_pago_view) {
                     </div>
                     <form id="order-form" method="POST" action="<?php echo $form_action; ?>">
                         <?php
-                            $default_estado = 'abierto';
+                            $default_estado = 'recibido';
                             if ($is_pago_view) {
                                 $default_estado = 'pagado';
                             } else if ($is_caja_create_view) {
@@ -234,7 +234,7 @@ if ($is_pago_view) {
                             </div>
                         </div>
 
-                        <?php if ($is_editing && !$is_pago_view): ?>
+                        <?php if ($is_editing): ?>
                         <fieldset class="status-actions-frame">
                             <legend>Acciones Rápidas de Estado</legend>
                             <div class="btn-group">

--- a/frontend_web/pedido_handler.php
+++ b/frontend_web/pedido_handler.php
@@ -19,7 +19,7 @@ $is_caja_create_view = $view === 'caja_create';
 // Recoger los datos del formulario
 $id_mesa = $_POST['id_mesa'] ?? null;
 $id_usuario_mozo = $_POST['id_usuario_mozo'] ?? null;
-$estado = $_POST['estado'] ?? 'abierto';
+$estado = $_POST['estado'] ?? 'recibido';
 $items_json = $_POST['items'] ?? '[]';
 $items = json_decode($items_json);
 


### PR DESCRIPTION
Se ha modificado la condición de visibilidad del grupo 'Acciones Rápidas de Estado' en el formulario de pedidos.

Anteriormente, este grupo de botones se ocultaba en la vista de pago (`view=pago`). Ahora, el grupo de acciones será visible siempre que se esté editando un pedido, independientemente de si se accede desde la vista de pago o no.

Esto responde a la solicitud del usuario de poder ver y utilizar estos botones al hacer clic en 'Pagar' desde la página de Caja.