### PR TITLE
feat(caja): Mostrar botón 'Editar' para pedidos cancelados

### DIFF
--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -60,6 +60,8 @@ $orders_data = getCompletedOrders();
                             <div class="card-footer">
                                 <?php if ($order['estado'] == 'completado'): ?>
                                     <a href="pedido_form.php?id=<?php echo $order['id']; ?>&view=pago" class="btn-card btn-edit">Pagar</a>
+                                <?php elseif ($order['estado'] == 'cancelado'): ?>
+                                    <a href="pedido_form.php?id=<?php echo $order['id']; ?>&view=pago" class="btn-card btn-edit" style="background-color: green; color: white;">Editar</a>
                                 <?php elseif ($order['estado'] == 'pagado'): ?>
                                     <a href="pedido_form.php?id=<?php echo $order['id']; ?>&view=pago" class="btn-card btn-view">Ver Detalle</a>
                                 <?php endif; ?>


### PR DESCRIPTION
Se ha modificado la página de 'Caja' (`caja.php`) para mejorar la gestión de los pedidos cancelados.

- Para los pedidos con estado 'Cancelado', ahora se muestra un botón 'Editar'.
- Este botón está estilizado con un fondo verde y texto blanco para destacarlo.
- El botón 'Editar' enlaza a la vista de pago, permitiendo al usuario reabrir o gestionar el pedido cancelado.
- La lógica para los pedidos 'Completado' y 'Pagado' se mantiene sin cambios.