### PR TITLE
fix(pedidos): Ocultar botón Cancelar si el pedido ya está cancelado

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -244,7 +244,9 @@ if ($is_pago_view) {
                                 <?php if ($order_data['estado'] !== 'completado'): ?>
                                     <button type="button" class="btn btn-completado status-btn" data-status="completado">Completar</button>
                                 <?php endif; ?>
-                                <button type="button" class="btn btn-cancelado status-btn" data-status="cancelado">Cancelar</button>
+                                <?php if ($order_data['estado'] !== 'cancelado'): ?>
+                                    <button type="button" class="btn btn-cancelado status-btn" data-status="cancelado">Cancelar</button>
+                                <?php endif; ?>
                             </div>
                         </fieldset>
                         <?php endif; ?>


### PR DESCRIPTION
Se ha añadido lógica condicional al formulario de edición de pedidos para ocultar el botón 'Cancelar' cuando el pedido ya tiene el estado 'cancelado'.

Esto previene que el usuario pueda realizar una acción redundante sobre un pedido que ya ha sido cancelado, mejorando la usabilidad de la interfaz.