### PR TITLE
refactor(pedidos): Ocultar el botón 'Ver Detalle' en la lista de pedidos

### DIFF
--- a/frontend_web/pedidos.php
+++ b/frontend_web/pedidos.php
@@ -64,7 +64,6 @@ $orders_data = getOrders('abierto');
                                 <p class="total"><strong>Total:</strong> <?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($order['total'], 2)); ?></p>
                             </div>
                             <div class="card-footer">
-                                <a href="pedido_detalle.php?id=<?php echo $order['id']; ?>" class="btn-card btn-view">Ver Detalle</a>
                                 <a href="pedido_form.php?id=<?php echo $order['id']; ?>" class="btn-card btn-edit">Editar</a>
                             </div>
                         </div>


### PR DESCRIPTION
Se ha eliminado el botón 'Ver Detalle' de las tarjetas de pedido en la página `pedidos.php`.

Esta modificación simplifica la interfaz de la tarjeta de pedido, dejando únicamente el botón 'Editar' como la acción principal disponible en esta vista.