### PR TITLE
feat: Implementar CRUD de Movimientos de Caja

### DIFF
--- a/backend/api/v1/movimientos_caja.php
+++ b/backend/api/v1/movimientos_caja.php
@@ -1,0 +1,140 @@
+<?php
+// Headers
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+session_start();
+
+include_once __DIR__ . '/../../config/app_config.php';
+include_once __DIR__ . '/../../core/Database.php';
+include_once __DIR__ . '/../../models/MovimientoCaja.php';
+
+$movimientoCaja = new MovimientoCaja();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            $movimiento_id = intval($_GET["id"]);
+            $movimiento_data = $movimientoCaja->readOne($movimiento_id);
+            if ($movimiento_data) {
+                http_response_code(200);
+                echo json_encode($movimiento_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Movimiento no encontrado."]);
+            }
+        } else {
+            $filters = [
+                'fecha_inicio' => $_GET['fecha_inicio'] ?? null,
+                'fecha_fin' => $_GET['fecha_fin'] ?? null,
+                'tipo_movimiento' => $_GET['tipo_movimiento'] ?? null,
+            ];
+            handleGetAllMovimientos($movimientoCaja, $filters);
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (
+            !empty($data->fecha) &&
+            !empty($data->tipo_movimiento) &&
+            isset($data->importe) &&
+            isset($_SESSION['user_id'])
+        ) {
+            $new_id = $movimientoCaja->create($data->fecha, $data->tipo_movimiento, $data->importe, $data->descripcion, $_SESSION['user_id']);
+            if ($new_id) {
+                http_response_code(201);
+                echo json_encode(["message" => "Movimiento creado.", "id" => $new_id]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear el movimiento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos o sesión no iniciada."]);
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        if (
+            !empty($data->id) &&
+            !empty($data->fecha) &&
+            !empty($data->tipo_movimiento) &&
+            isset($data->importe)
+        ) {
+            if ($movimientoCaja->update($data->id, $data->fecha, $data->tipo_movimiento, $data->importe, $data->descripcion)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Movimiento actualizado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar el movimiento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+
+    case 'DELETE':
+        if (!empty($_GET["id"])) {
+            $movimiento_id = intval($_GET["id"]);
+            if ($movimientoCaja->delete($movimiento_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Movimiento eliminado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar el movimiento."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+
+function handleGetAllMovimientos($movimientoCaja, $filters) {
+    $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
+    $page_size = isset($_GET['page_size']) ? intval($_GET['page_size']) : 10;
+
+    $stmt = $movimientoCaja->readAll($filters, $page, $page_size);
+    $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->closeCursor();
+
+    $total_records = $movimientoCaja->countAll($filters);
+    $total_pages = ($page_size > 0) ? ceil($total_records / $page_size) : 1;
+
+    if (count($records) > 0) {
+        http_response_code(200);
+        echo json_encode([
+            "records" => $records,
+            "pagination" => [
+                "page" => $page,
+                "page_size" => $page_size,
+                "total_pages" => $total_pages,
+                "total_records" => $total_records
+            ]
+        ]);
+    } else {
+        http_response_code(404);
+        echo json_encode([
+            "message" => "No se encontraron movimientos.",
+            "records" => [],
+            "pagination" => [
+                "page" => $page,
+                "page_size" => $page_size,
+                "total_pages" => 0,
+                "total_records" => 0
+            ]
+        ]);
+    }
+}
+?>

--- a/backend/migrations/20250922_create_movimientos_caja_table.sql
+++ b/backend/migrations/20250922_create_movimientos_caja_table.sql
@@ -1,0 +1,16 @@
+-- Creación de la tabla para registrar los movimientos de caja (entradas y salidas de dinero)
+
+CREATE TABLE IF NOT EXISTS `movimientos_caja` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `fecha` DATETIME NOT NULL COMMENT 'Fecha y hora del movimiento',
+  `tipo_movimiento` ENUM('entrada', 'salida') NOT NULL COMMENT 'Tipo de movimiento: entrada o salida de dinero',
+  `importe` DECIMAL(10, 2) NOT NULL COMMENT 'Monto del movimiento',
+  `descripcion` TEXT COMMENT 'Descripción o concepto del movimiento',
+  `usuario_id` INT NOT NULL COMMENT 'ID del usuario que registra el movimiento',
+  `fecha_creacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  `fecha_actualizacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (`usuario_id`) REFERENCES `usuarios`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Agregar un comentario a la tabla para describir su propósito
+ALTER TABLE `movimientos_caja` COMMENT = 'Registra las entradas y salidas de dinero de la caja, como un kardex.';

--- a/backend/models/MovimientoCaja.php
+++ b/backend/models/MovimientoCaja.php
@@ -1,0 +1,182 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class MovimientoCaja {
+    private $conn;
+    private $table_name = "movimientos_caja";
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    /**
+     * Lee todos los movimientos de caja con filtros y paginación.
+     */
+    public function readAll($filters = [], $page = 1, $page_size = 10) {
+        $query = "SELECT m.id, m.fecha, m.tipo_movimiento, m.importe, m.descripcion, m.usuario_id, u.nombre_completo as usuario_nombre
+                  FROM " . $this->table_name . " m
+                  LEFT JOIN usuarios u ON m.usuario_id = u.id";
+
+        $where_clauses = [];
+        $params = [];
+
+        if (!empty($filters['fecha_inicio'])) {
+            $where_clauses[] = "m.fecha >= :fecha_inicio";
+            $params[':fecha_inicio'] = $filters['fecha_inicio'];
+        }
+        if (!empty($filters['fecha_fin'])) {
+            // Se suma un día para incluir todos los movimientos del día final
+            $fecha_fin = date('Y-m-d', strtotime($filters['fecha_fin'] . ' +1 day'));
+            $where_clauses[] = "m.fecha < :fecha_fin";
+            $params[':fecha_fin'] = $fecha_fin;
+        }
+        if (!empty($filters['tipo_movimiento'])) {
+            $where_clauses[] = "m.tipo_movimiento = :tipo_movimiento";
+            $params[':tipo_movimiento'] = $filters['tipo_movimiento'];
+        }
+
+        if (count($where_clauses) > 0) {
+            $query .= " WHERE " . implode(' AND ', $where_clauses);
+        }
+
+        $query .= " ORDER BY m.fecha DESC";
+
+        if ($page_size > 0) {
+            $offset = ($page - 1) * $page_size;
+            $query .= " LIMIT :offset, :page_size";
+            $params[':offset'] = $offset;
+            $params[':page_size'] = $page_size;
+        }
+
+        $stmt = $this->conn->prepare($query);
+
+        foreach ($params as $key => &$val) {
+            if (is_int($val)) {
+                $stmt->bindParam($key, $val, PDO::PARAM_INT);
+            } else {
+                $stmt->bindParam($key, $val, PDO::PARAM_STR);
+            }
+        }
+
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Cuenta el total de registros con los filtros aplicados.
+     */
+    public function countAll($filters = []) {
+        $query = "SELECT COUNT(*) as total_records FROM " . $this->table_name;
+
+        $where_clauses = [];
+        $params = [];
+
+        if (!empty($filters['fecha_inicio'])) {
+            $where_clauses[] = "fecha >= :fecha_inicio";
+            $params[':fecha_inicio'] = $filters['fecha_inicio'];
+        }
+        if (!empty($filters['fecha_fin'])) {
+            $fecha_fin = date('Y-m-d', strtotime($filters['fecha_fin'] . ' +1 day'));
+            $where_clauses[] = "fecha < :fecha_fin";
+            $params[':fecha_fin'] = $fecha_fin;
+        }
+        if (!empty($filters['tipo_movimiento'])) {
+            $where_clauses[] = "tipo_movimiento = :tipo_movimiento";
+            $params[':tipo_movimiento'] = $filters['tipo_movimiento'];
+        }
+
+        if (count($where_clauses) > 0) {
+            $query .= " WHERE " . implode(' AND ', $where_clauses);
+        }
+
+        $stmt = $this->conn->prepare($query);
+
+        foreach ($params as $key => &$val) {
+            $stmt->bindParam($key, $val, PDO::PARAM_STR);
+        }
+
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row['total_records'];
+    }
+
+    /**
+     * Crea un nuevo movimiento de caja.
+     */
+    public function create($fecha, $tipo_movimiento, $importe, $descripcion, $usuario_id) {
+        $query = "INSERT INTO " . $this->table_name . " (fecha, tipo_movimiento, importe, descripcion, usuario_id) VALUES (:fecha, :tipo_movimiento, :importe, :descripcion, :usuario_id)";
+        $stmt = $this->conn->prepare($query);
+
+        // Limpiar datos
+        $fecha = htmlspecialchars(strip_tags($fecha));
+        $tipo_movimiento = htmlspecialchars(strip_tags($tipo_movimiento));
+        $importe = htmlspecialchars(strip_tags($importe));
+        $descripcion = htmlspecialchars(strip_tags($descripcion));
+        $usuario_id = htmlspecialchars(strip_tags($usuario_id));
+
+        // Enlazar parámetros
+        $stmt->bindParam(':fecha', $fecha);
+        $stmt->bindParam(':tipo_movimiento', $tipo_movimiento);
+        $stmt->bindParam(':importe', $importe);
+        $stmt->bindParam(':descripcion', $descripcion);
+        $stmt->bindParam(':usuario_id', $usuario_id);
+
+        if ($stmt->execute()) {
+            return $this->conn->lastInsertId();
+        }
+        return false;
+    }
+
+    /**
+     * Lee un solo movimiento por su ID.
+     */
+    public function readOne($id) {
+        $query = "SELECT id, fecha, tipo_movimiento, importe, descripcion, usuario_id FROM " . $this->table_name . " WHERE id = :id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Actualiza un movimiento de caja existente.
+     */
+    public function update($id, $fecha, $tipo_movimiento, $importe, $descripcion) {
+        $query = "UPDATE " . $this->table_name . " SET fecha = :fecha, tipo_movimiento = :tipo_movimiento, importe = :importe, descripcion = :descripcion WHERE id = :id";
+        $stmt = $this->conn->prepare($query);
+
+        // Limpiar datos
+        $id = htmlspecialchars(strip_tags($id));
+        $fecha = htmlspecialchars(strip_tags($fecha));
+        $tipo_movimiento = htmlspecialchars(strip_tags($tipo_movimiento));
+        $importe = htmlspecialchars(strip_tags($importe));
+        $descripcion = htmlspecialchars(strip_tags($descripcion));
+
+        // Enlazar parámetros
+        $stmt->bindParam(':id', $id);
+        $stmt->bindParam(':fecha', $fecha);
+        $stmt->bindParam(':tipo_movimiento', $tipo_movimiento);
+        $stmt->bindParam(':importe', $importe);
+        $stmt->bindParam(':descripcion', $descripcion);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Elimina un movimiento de caja.
+     */
+    public function delete($id) {
+        $query = "DELETE FROM " . $this->table_name . " WHERE id = :id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+        return false;
+    }
+}
+?>

--- a/frontend_web/movim_caja.php
+++ b/frontend_web/movim_caja.php
@@ -8,6 +8,7 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
 
 $page_title = 'Movimientos de Caja';
 include_once 'templates/header.php';
+include_once __DIR__ . '/config.php';
 ?>
 
 <div class="dashboard-container">
@@ -15,8 +16,240 @@ include_once 'templates/header.php';
 
     <main class="main-content">
         <div class="container">
-            <h1>Movimientos de Caja</h1>
-            <p>El contenido de la página de movimientos de caja irá aquí.</p>
+            <div class="page-header">
+                <h1>Historial de Movimientos de Caja</h1>
+                <a href="movimiento_caja_form.php" class="btn">Registrar Nuevo Movimiento</a>
+            </div>
+
+            <div class="filter-container">
+                <form id="filter-form">
+                    <div class="filters">
+                        <input type="date" id="fecha_inicio" name="fecha_inicio" title="Fecha desde">
+                        <input type="date" id="fecha_fin" name="fecha_fin" title="Fecha hasta">
+                        <select id="tipo_movimiento" name="tipo_movimiento">
+                            <option value="">Todos los tipos</option>
+                            <option value="entrada">Entrada</option>
+                            <option value="salida">Salida</option>
+                        </select>
+                        <button type="submit" class="btn">Filtrar</button>
+                    </div>
+                </form>
+            </div>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Fecha</th>
+                            <th>Tipo</th>
+                            <th>Importe</th>
+                            <th>Descripción</th>
+                            <th>Usuario</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="movimientos-tbody">
+                        <!-- Las filas de datos se insertarán aquí dinámicamente -->
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="pagination-container">
+                <div id="pagination-controls"></div>
+                <div class="page-size-selector">
+                    <label for="page-size">Registros por página:</label>
+                    <select id="page-size">
+                        <option value="10" selected>10</option>
+                        <option value="25">25</option>
+                        <option value="50">50</option>
+                        <option value="100">100</option>
+                    </select>
+                </div>
+            </div>
         </div>
     </main>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const API_URL = '<?php echo API_BASE_URL; ?>movimientos_caja.php';
+    const tbody = document.getElementById('movimientos-tbody');
+    const filterForm = document.getElementById('filter-form');
+    const paginationControls = document.getElementById('pagination-controls');
+    const pageSizeSelector = document.getElementById('page-size');
+
+    let currentPage = 1;
+
+    async function fetchMovimientos() {
+        const pageSize = pageSizeSelector.value;
+        const fechaInicio = document.getElementById('fecha_inicio').value;
+        const fechaFin = document.getElementById('fecha_fin').value;
+        const tipoMovimiento = document.getElementById('tipo_movimiento').value;
+
+        let queryParams = `?page=${currentPage}&page_size=${pageSize}`;
+        if (fechaInicio) queryParams += `&fecha_inicio=${fechaInicio}`;
+        if (fechaFin) queryParams += `&fecha_fin=${fechaFin}`;
+        if (tipoMovimiento) queryParams += `&tipo_movimiento=${tipoMovimiento}`;
+
+        try {
+            const response = await fetch(API_URL + queryParams);
+            if (!response.ok) {
+                if (response.status === 404) {
+                    tbody.innerHTML = '<tr><td colspan="6">No se encontraron movimientos.</td></tr>';
+                    updatePagination(null);
+                } else {
+                    throw new Error('Error en la respuesta de la red: ' + response.statusText);
+                }
+                return;
+            }
+
+            const data = await response.json();
+            renderTable(data.records);
+            updatePagination(data.pagination);
+
+        } catch (error) {
+            console.error('Error al obtener los movimientos:', error);
+            tbody.innerHTML = '<tr><td colspan="6">Error al cargar los datos. Por favor, intente de nuevo.</td></tr>';
+        }
+    }
+
+    function renderTable(movimientos) {
+        tbody.innerHTML = '';
+        if (!movimientos || movimientos.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6">No hay movimientos que coincidan con los filtros.</td></tr>';
+            return;
+        }
+
+        movimientos.forEach(mov => {
+            const tr = document.createElement('tr');
+            const importeClass = mov.tipo_movimiento === 'entrada' ? 'text-success' : 'text-danger';
+            const importeSign = mov.tipo_movimiento === 'entrada' ? '+' : '-';
+
+            tr.innerHTML = `
+                <td data-label="Fecha">${new Date(mov.fecha).toLocaleString()}</td>
+                <td data-label="Tipo">${mov.tipo_movimiento.charAt(0).toUpperCase() + mov.tipo_movimiento.slice(1)}</td>
+                <td data-label="Importe" class="${importeClass}">${importeSign} <?php echo CURRENCY_SYMBOL; ?>${parseFloat(mov.importe).toFixed(2)}</td>
+                <td data-label="Descripción">${mov.descripcion || ''}</td>
+                <td data-label="Usuario">${mov.usuario_nombre || 'N/A'}</td>
+                <td data-label="Acciones" class="actions-cell">
+                    <a href="movimiento_caja_form.php?id=${mov.id}" class="btn btn-edit">Editar</a>
+                    <button class="btn btn-delete" data-id="${mov.id}">Eliminar</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    function updatePagination(pagination) {
+        paginationControls.innerHTML = '';
+        if (!pagination || pagination.total_pages <= 1) {
+            return;
+        }
+
+        const { page, total_pages } = pagination;
+
+        // Botón Anterior
+        const prevButton = document.createElement('button');
+        prevButton.innerText = '« Anterior';
+        prevButton.disabled = page <= 1;
+        prevButton.addEventListener('click', () => {
+            if (currentPage > 1) {
+                currentPage--;
+                fetchMovimientos();
+            }
+        });
+        paginationControls.appendChild(prevButton);
+
+        // Números de página
+        for (let i = 1; i <= total_pages; i++) {
+            const pageButton = document.createElement('button');
+            pageButton.innerText = i;
+            pageButton.classList.toggle('active', i === page);
+            pageButton.addEventListener('click', () => {
+                currentPage = i;
+                fetchMovimientos();
+            });
+            paginationControls.appendChild(pageButton);
+        }
+
+        // Botón Siguiente
+        const nextButton = document.createElement('button');
+        nextButton.innerText = 'Siguiente »';
+        nextButton.disabled = page >= total_pages;
+        nextButton.addEventListener('click', () => {
+            if (currentPage < total_pages) {
+                currentPage++;
+                fetchMovimientos();
+            }
+        });
+        paginationControls.appendChild(nextButton);
+    }
+
+    filterForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        currentPage = 1;
+        fetchMovimientos();
+    });
+
+    pageSizeSelector.addEventListener('change', function() {
+        currentPage = 1;
+        fetchMovimientos();
+    });
+
+    tbody.addEventListener('click', function(e) {
+        if (e.target.classList.contains('btn-delete')) {
+            const movimientoId = e.target.getAttribute('data-id');
+            if (confirm('¿Estás seguro de que quieres eliminar este movimiento?')) {
+                deleteMovimiento(movimientoId);
+            }
+        }
+    });
+
+    async function deleteMovimiento(id) {
+        try {
+            // Llamar directamente a la API del backend
+            const response = await fetch(`${API_URL}?id=${id}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            const result = await response.json();
+
+            if (response.ok) {
+                alert(result.message || 'Movimiento eliminado con éxito.');
+                fetchMovimientos(); // Recargar la tabla
+            } else {
+                alert('Error al eliminar: ' + (result.message || 'Error desconocido'));
+            }
+
+        } catch (error) {
+            console.error('Error al eliminar:', error);
+            alert('Ocurrió un error de red al intentar eliminar el movimiento.');
+        }
+    }
+
+    // Carga inicial
+    fetchMovimientos();
+});
+</script>
+
+<style>
+.text-success { color: #28a745; font-weight: bold; }
+.text-danger { color: #dc3545; font-weight: bold; }
+.pagination-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1rem;
+}
+#pagination-controls button {
+    margin: 0 2px;
+}
+#pagination-controls button.active {
+    font-weight: bold;
+    background-color: #007bff;
+    color: white;
+}
+</style>

--- a/frontend_web/movimiento_caja_form.php
+++ b/frontend_web/movimiento_caja_form.php
@@ -1,0 +1,90 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+include_once 'templates/header.php';
+include_once __DIR__ . '/config.php';
+
+// Función auxiliar para obtener datos de la API
+function getAPIData($endpoint) {
+    $api_url = API_BASE_URL . $endpoint;
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($httpcode >= 400) {
+        return null;
+    }
+    return json_decode($response, true);
+}
+
+$is_editing = false;
+$movimiento_data = null;
+$page_title = 'Registrar Nuevo Movimiento';
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $movimiento_id = intval($_GET['id']);
+    $page_title = 'Editar Movimiento';
+    $movimiento_data = getAPIData("movimientos_caja.php?id=$movimiento_id");
+
+    // Formatear la fecha para el input type="datetime-local"
+    if ($movimiento_data && !empty($movimiento_data['fecha'])) {
+        $movimiento_data['fecha'] = (new DateTime($movimiento_data['fecha']))->format('Y-m-d\TH:i');
+    }
+}
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo htmlspecialchars($page_title); ?></h1>
+                <a href="movim_caja.php" class="btn btn-secondary">Volver a Lista</a>
+            </div>
+
+            <?php if (isset($_GET['error'])): ?>
+                <p class="error-message"><?php echo htmlspecialchars($_GET['error']); ?></p>
+            <?php endif; ?>
+
+            <div class="form-container">
+                <form action="movimiento_caja_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($movimiento_data['id'] ?? ''); ?>">
+                    <input type="hidden" name="action" value="<?php echo $is_editing ? 'update' : 'create'; ?>">
+
+                    <div class="form-group">
+                        <label for="fecha">Fecha y Hora</label>
+                        <input type="datetime-local" id="fecha" name="fecha" value="<?php echo htmlspecialchars($movimiento_data['fecha'] ?? date('Y-m-d\TH:i')); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="tipo_movimiento">Tipo de Movimiento</label>
+                        <select id="tipo_movimiento" name="tipo_movimiento" required>
+                            <option value="entrada" <?php echo (isset($movimiento_data['tipo_movimiento']) && $movimiento_data['tipo_movimiento'] == 'entrada') ? 'selected' : ''; ?>>Entrada</option>
+                            <option value="salida" <?php echo (isset($movimiento_data['tipo_movimiento']) && $movimiento_data['tipo_movimiento'] == 'salida') ? 'selected' : ''; ?>>Salida</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="importe">Importe</label>
+                        <input type="number" id="importe" name="importe" step="0.01" min="0.01" value="<?php echo htmlspecialchars($movimiento_data['importe'] ?? ''); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="descripcion">Descripción</label>
+                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($movimiento_data['descripcion'] ?? ''); ?></textarea>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar Movimiento' : 'Guardar Movimiento'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>

--- a/frontend_web/movimiento_caja_handler.php
+++ b/frontend_web/movimiento_caja_handler.php
@@ -1,0 +1,70 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    require_once 'config.php';
+    $action = $_POST['action'] ?? '';
+    $api_url = API_BASE_URL . 'movimientos_caja.php';
+
+    $data = [
+        'fecha' => $_POST['fecha'] ?? '',
+        'tipo_movimiento' => $_POST['tipo_movimiento'] ?? '',
+        'importe' => $_POST['importe'] ?? '',
+        'descripcion' => $_POST['descripcion'] ?? '',
+        'usuario_id' => $_SESSION['user_id']
+    ];
+
+    $ch = curl_init();
+
+    // Para que la API pueda acceder a la sesión, debemos pasar el ID de sesión
+    curl_setopt($ch, CURLOPT_COOKIE, "PHPSESSID=" . session_id());
+
+    if ($action == 'create') {
+        curl_setopt($ch, CURLOPT_URL, $api_url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    } elseif ($action == 'update') {
+        $data['id'] = $_POST['id'];
+        curl_setopt($ch, CURLOPT_URL, $api_url);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    } else {
+        header('Location: movim_caja.php?error=Acción no válida');
+        exit();
+    }
+
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($http_code == 200 || $http_code == 201) {
+        $success_message = ($action == 'create') ? 'Movimiento registrado con éxito.' : 'Movimiento actualizado con éxito.';
+        header('Location: movim_caja.php?success=' . urlencode($success_message));
+    } else {
+        $error_data = json_decode($response, true);
+        $error_message = $error_data['message'] ?? 'Ocurrió un error en la operación.';
+        // Redirigir de vuelta al formulario con el error
+        $redirect_url = 'movimiento_caja_form.php?error=' . urlencode($error_message);
+        if ($action == 'update') {
+            $redirect_url .= '&id=' . $_POST['id'];
+        }
+        header('Location: ' . $redirect_url);
+    }
+    exit();
+
+} else {
+    header('Location: movim_caja.php');
+    exit();
+}
+?>


### PR DESCRIPTION
Se añade una nueva funcionalidad para la gestión de movimientos de caja (entradas y salidas de dinero) en la página `movim_caja.php`.

Esta implementación incluye:
- Creación de la tabla `movimientos_caja` en la base de datos a través de un nuevo script de migración.
- Un nuevo modelo `MovimientoCaja.php` para gestionar las operaciones con la base de datos.
- Un endpoint de API RESTful para las operaciones CRUD sobre los movimientos.
- Una vista principal en `movim_caja.php` que muestra una grilla dinámica con filtros por fecha y tipo, y paginación.
- Un formulario en `movimiento_caja_form.php` para crear y editar movimientos.
- Manejadores en el frontend para procesar los formularios y comunicarse con la API.
- Toda la funcionalidad y el código están en español, según lo solicitado.