### PR TITLE
fix: Resolver bloqueo de sesión en el formulario de movimientos de caja

### DIFF
--- a/frontend_web/movimiento_caja_handler.php
+++ b/frontend_web/movimiento_caja_handler.php
@@ -19,10 +19,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         'usuario_id' => $_SESSION['user_id']
     ];
 
+    // Cerramos la sesión para evitar bloqueos. La API la reabrirá.
+    session_write_close();
+
     $ch = curl_init();
 
     // Para que la API pueda acceder a la sesión, debemos pasar el ID de sesión
-    curl_setopt($ch, CURLOPT_COOKIE, "PHPSESSID=" . session_id());
+    curl_setopt($ch, CURLOPT_COOKIE, "PHPSESSID=" . $_COOKIE['PHPSESSID']);
 
     if ($action == 'create') {
         curl_setopt($ch, CURLOPT_URL, $api_url);


### PR DESCRIPTION
Se corrige un error que causaba que el formulario de creación y edición de movimientos de caja se quedara en estado "pendiente" indefinidamente.

El problema se debía a un bloqueo de sesión (deadlock) entre el script manejador del formulario (`movimiento_caja_handler.php`) y el endpoint de la API.

La solución consiste en cerrar la sesión en el manejador (`session_write_close()`) antes de realizar la llamada cURL a la API, lo que libera el bloqueo y permite que la solicitud se complete con éxito.