### PR TITLE
fix: Refinar estilos de los filtros en Movimientos de Caja

### DIFF
--- a/frontend_web/movim_caja.php
+++ b/frontend_web/movim_caja.php
@@ -265,13 +265,21 @@ document.addEventListener('DOMContentLoaded', function() {
 .filter-container .filters {
     display: flex;
     flex-wrap: wrap;
-    gap: 15px;
+    gap: 10px; /* Reducir el espacio para un look más compacto */
     align-items: center;
 }
 .filter-container .filters input,
-.filter-container .filters select {
+.filter-container .filters select,
+.filter-container .filters button {
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+.filter-container .filters input[type="date"] {
+    width: auto; /* El navegador determinará el ancho */
     padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+}
+.filter-container .filters select {
+    width: 150px; /* Ancho fijo para el desplegable */
+    padding: 8px;
 }
 </style>


### PR DESCRIPTION
Se ajusta el CSS de los controles de filtro en la página `movim_caja.php` para mejorar su apariencia visual.

- Se establece un ancho más apropiado para los campos de fecha y el menú desplegable, evitando que se estiren de forma desproporcionada.
- Se utiliza `flex-grow: 0` y `flex-shrink: 0` para que los controles mantengan su tamaño intrínseco.
- Esto da como resultado un diseño más limpio, profesional y organizado, según lo solicitado por el usuario.