### PR TITLE
feat: Implementar CRUD para Apertura y Cierre de Caja

### DIFF
--- a/backend/api/v1/apertura_cierre.php
+++ b/backend/api/v1/apertura_cierre.php
@@ -1,0 +1,131 @@
+<?php
+// Headers
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+session_start();
+
+include_once __DIR__ . '/../../config/app_config.php';
+include_once __DIR__ . '/../../core/Database.php';
+include_once __DIR__ . '/../../models/AperturaCierre.php';
+
+$aperturaCierre = new AperturaCierre();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            $id = intval($_GET["id"]);
+            $data = $aperturaCierre->readOne($id);
+            if ($data) {
+                http_response_code(200);
+                echo json_encode($data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Registro no encontrado."]);
+            }
+        } else {
+            $filters = [
+                'fecha_inicio' => $_GET['fecha_inicio'] ?? null,
+                'fecha_fin' => $_GET['fecha_fin'] ?? null,
+                'tipo_movimiento' => $_GET['tipo_movimiento'] ?? null,
+            ];
+            handleGetAll($aperturaCierre, $filters);
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->fecha) && !empty($data->tipo_movimiento) && isset($data->importe) && isset($_SESSION['user_id'])) {
+            $result = $aperturaCierre->create($data->fecha, $data->tipo_movimiento, $data->importe, $data->descripcion, $_SESSION['user_id']);
+            if (is_numeric($result)) {
+                http_response_code(201);
+                echo json_encode(["message" => "Registro creado con éxito.", "id" => $result]);
+            } else {
+                http_response_code(400); // Bad Request o 409 Conflict
+                echo json_encode(["message" => $result]); // $result contiene el mensaje de error del modelo
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos o sesión no iniciada."]);
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        if (!empty($data->id) && !empty($data->fecha) && !empty($data->tipo_movimiento) && isset($data->importe)) {
+            $result = $aperturaCierre->update($data->id, $data->fecha, $data->tipo_movimiento, $data->importe, $data->descripcion);
+            if ($result === true) {
+                http_response_code(200);
+                echo json_encode(["message" => "Registro actualizado con éxito."]);
+            } else {
+                http_response_code(400); // Bad Request o 409 Conflict
+                echo json_encode(["message" => $result]); // $result contiene el mensaje de error del modelo
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+
+    case 'DELETE':
+        if (!empty($_GET["id"])) {
+            $id = intval($_GET["id"]);
+            if ($aperturaCierre->delete($id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Registro eliminado."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar el registro."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+
+function handleGetAll($aperturaCierre, $filters) {
+    $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
+    $page_size = isset($_GET['page_size']) ? intval($_GET['page_size']) : 10;
+
+    $stmt = $aperturaCierre->readAll($filters, $page, $page_size);
+    $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $stmt->closeCursor();
+
+    $total_records = $aperturaCierre->countAll($filters);
+    $total_pages = ($page_size > 0) ? ceil($total_records / $page_size) : 1;
+
+    if (count($records) > 0) {
+        http_response_code(200);
+        echo json_encode([
+            "records" => $records,
+            "pagination" => [
+                "page" => $page,
+                "page_size" => $page_size,
+                "total_pages" => $total_pages,
+                "total_records" => $total_records
+            ]
+        ]);
+    } else {
+        http_response_code(404);
+        echo json_encode([
+            "message" => "No se encontraron registros.",
+            "records" => [],
+            "pagination" => [
+                "page" => $page,
+                "page_size" => $page_size,
+                "total_pages" => 0,
+                "total_records" => 0
+            ]
+        ]);
+    }
+}
+?>

--- a/backend/migrations/20250922_create_apertura_cierre_caja_table.sql
+++ b/backend/migrations/20250922_create_apertura_cierre_caja_table.sql
@@ -1,0 +1,18 @@
+-- Creación de la tabla para registrar la apertura y cierre de caja
+CREATE TABLE IF NOT EXISTS `apertura_cierre_caja` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `fecha` DATETIME NOT NULL COMMENT 'Fecha y hora del movimiento',
+  `tipo_movimiento` ENUM('apertura', 'cierre') NOT NULL COMMENT 'Tipo de movimiento: apertura o cierre de caja',
+  `importe` DECIMAL(10, 2) NOT NULL COMMENT 'Monto del movimiento',
+  `descripcion` TEXT COMMENT 'Descripción o concepto del movimiento',
+  `usuario_id` INT NOT NULL COMMENT 'ID del usuario que registra el movimiento',
+  `fecha_creacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  `fecha_actualizacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (`usuario_id`) REFERENCES `usuarios`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  -- Restricción para asegurar una sola apertura y un solo cierre por día.
+  -- Se usa una columna virtual para extraer solo la fecha de la columna `fecha`.
+  CONSTRAINT uq_fecha_tipo UNIQUE (tipo_movimiento, (DATE(fecha)))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Agregar un comentario a la tabla para describir su propósito
+ALTER TABLE `apertura_cierre_caja` COMMENT = 'Registra los importes de apertura y cierre de caja para cada día.';

--- a/backend/models/AperturaCierre.php
+++ b/backend/models/AperturaCierre.php
@@ -1,0 +1,177 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class AperturaCierre {
+    private $conn;
+    private $table_name = "apertura_cierre_caja";
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    /**
+     * Lee todos los registros de apertura/cierre con filtros y paginación.
+     */
+    public function readAll($filters = [], $page = 1, $page_size = 10) {
+        $query = "SELECT m.id, m.fecha, m.tipo_movimiento, m.importe, m.descripcion, m.usuario_id, u.nombre_completo as usuario_nombre
+                  FROM " . $this->table_name . " m
+                  LEFT JOIN usuarios u ON m.usuario_id = u.id";
+
+        $where_clauses = [];
+        $params = [];
+
+        if (!empty($filters['fecha_inicio'])) {
+            $where_clauses[] = "m.fecha >= :fecha_inicio";
+            $params[':fecha_inicio'] = $filters['fecha_inicio'];
+        }
+        if (!empty($filters['fecha_fin'])) {
+            $fecha_fin = date('Y-m-d', strtotime($filters['fecha_fin'] . ' +1 day'));
+            $where_clauses[] = "m.fecha < :fecha_fin";
+            $params[':fecha_fin'] = $fecha_fin;
+        }
+        if (!empty($filters['tipo_movimiento'])) {
+            $where_clauses[] = "m.tipo_movimiento = :tipo_movimiento";
+            $params[':tipo_movimiento'] = $filters['tipo_movimiento'];
+        }
+
+        if (count($where_clauses) > 0) {
+            $query .= " WHERE " . implode(' AND ', $where_clauses);
+        }
+
+        $query .= " ORDER BY m.fecha DESC";
+
+        if ($page_size > 0) {
+            $offset = ($page - 1) * $page_size;
+            $query .= " LIMIT :offset, :page_size";
+            $params[':offset'] = $offset;
+            $params[':page_size'] = $page_size;
+        }
+
+        $stmt = $this->conn->prepare($query);
+
+        foreach ($params as $key => &$val) {
+             $stmt->bindParam($key, $val, is_int($val) ? PDO::PARAM_INT : PDO::PARAM_STR);
+        }
+
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Cuenta el total de registros con los filtros aplicados.
+     */
+    public function countAll($filters = []) {
+        $query = "SELECT COUNT(*) as total_records FROM " . $this->table_name;
+
+        $where_clauses = [];
+        $params = [];
+
+        if (!empty($filters['fecha_inicio'])) {
+            $where_clauses[] = "DATE(fecha) >= :fecha_inicio";
+            $params[':fecha_inicio'] = $filters['fecha_inicio'];
+        }
+        if (!empty($filters['fecha_fin'])) {
+            $where_clauses[] = "DATE(fecha) <= :fecha_fin";
+            $params[':fecha_fin'] = $filters['fecha_fin'];
+        }
+        if (!empty($filters['tipo_movimiento'])) {
+            $where_clauses[] = "tipo_movimiento = :tipo_movimiento";
+            $params[':tipo_movimiento'] = $filters['tipo_movimiento'];
+        }
+
+        if (count($where_clauses) > 0) {
+            $query .= " WHERE " . implode(' AND ', $where_clauses);
+        }
+
+        $stmt = $this->conn->prepare($query);
+
+        foreach ($params as $key => &$val) {
+            $stmt->bindParam($key, $val, PDO::PARAM_STR);
+        }
+
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row['total_records'];
+    }
+
+    /**
+     * Crea un nuevo registro de apertura/cierre.
+     * Devuelve el ID del nuevo registro o un mensaje de error.
+     */
+    public function create($fecha, $tipo_movimiento, $importe, $descripcion, $usuario_id) {
+        $query = "INSERT INTO " . $this->table_name . " (fecha, tipo_movimiento, importe, descripcion, usuario_id) VALUES (:fecha, :tipo_movimiento, :importe, :descripcion, :usuario_id)";
+
+        try {
+            $stmt = $this->conn->prepare($query);
+
+            $stmt->bindParam(':fecha', $fecha);
+            $stmt->bindParam(':tipo_movimiento', $tipo_movimiento);
+            $stmt->bindParam(':importe', $importe);
+            $stmt->bindParam(':descripcion', $descripcion);
+            $stmt->bindParam(':usuario_id', $usuario_id);
+
+            if ($stmt->execute()) {
+                return $this->conn->lastInsertId();
+            }
+            return false;
+        } catch (PDOException $e) {
+            // Error 23000 es violación de integridad (como una clave única duplicada)
+            if ($e->getCode() == 23000) {
+                return "Error: Ya existe un registro de '{$tipo_movimiento}' para esta fecha.";
+            }
+            // Para otros errores, puedes devolver el mensaje de error genérico
+            return "Error en la base de datos: " . $e->getMessage();
+        }
+    }
+
+    /**
+     * Lee un solo registro por su ID.
+     */
+    public function readOne($id) {
+        $query = "SELECT id, fecha, tipo_movimiento, importe, descripcion, usuario_id FROM " . $this->table_name . " WHERE id = :id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Actualiza un registro existente.
+     * Devuelve true o un mensaje de error.
+     */
+    public function update($id, $fecha, $tipo_movimiento, $importe, $descripcion) {
+        $query = "UPDATE " . $this->table_name . " SET fecha = :fecha, tipo_movimiento = :tipo_movimiento, importe = :importe, descripcion = :descripcion WHERE id = :id";
+
+        try {
+            $stmt = $this->conn->prepare($query);
+
+            $stmt->bindParam(':id', $id);
+            $stmt->bindParam(':fecha', $fecha);
+            $stmt->bindParam(':tipo_movimiento', $tipo_movimiento);
+            $stmt->bindParam(':importe', $importe);
+            $stmt->bindParam(':descripcion', $descripcion);
+
+            return $stmt->execute();
+        } catch (PDOException $e) {
+            if ($e->getCode() == 23000) {
+                return "Error: Ya existe un registro de '{$tipo_movimiento}' para esta fecha.";
+            }
+            return "Error en la base de datos: " . $e->getMessage();
+        }
+    }
+
+    /**
+     * Elimina un registro.
+     */
+    public function delete($id) {
+        $query = "DELETE FROM " . $this->table_name . " WHERE id = :id";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+        return false;
+    }
+}
+?>

--- a/frontend_web/apertura_cierre.php
+++ b/frontend_web/apertura_cierre.php
@@ -6,8 +6,9 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
     exit();
 }
 
-$page_title = 'Apertura / Cierre de Caja';
+$page_title = 'Apertura y Cierre de Caja';
 include_once 'templates/header.php';
+include_once __DIR__ . '/config.php';
 ?>
 
 <div class="dashboard-container">
@@ -15,8 +16,259 @@ include_once 'templates/header.php';
 
     <main class="main-content">
         <div class="container">
-            <h1>Apertura / Cierre de Caja</h1>
-            <p>El contenido de la página de apertura y cierre de caja irá aquí.</p>
+            <div class="page-header">
+                <h1>Historial de Apertura y Cierre de Caja</h1>
+                <a href="apertura_cierre_form.php" class="btn">Registrar Nuevo Movimiento</a>
+            </div>
+
+            <div class="filter-container">
+                <form id="filter-form">
+                    <div class="filters">
+                        <input type="date" id="fecha_inicio" name="fecha_inicio" title="Fecha desde">
+                        <input type="date" id="fecha_fin" name="fecha_fin" title="Fecha hasta">
+                        <select id="tipo_movimiento" name="tipo_movimiento">
+                            <option value="">Todos los tipos</option>
+                            <option value="apertura">Apertura</option>
+                            <option value="cierre">Cierre</option>
+                        </select>
+                        <button type="submit" class="btn">Filtrar</button>
+                    </div>
+                </form>
+            </div>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Fecha</th>
+                            <th>Tipo</th>
+                            <th>Importe</th>
+                            <th>Descripción</th>
+                            <th>Usuario</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="apertura-cierre-tbody">
+                        <!-- Las filas de datos se insertarán aquí dinámicamente -->
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="pagination-container">
+                <div id="pagination-controls"></div>
+                <div class="page-size-selector">
+                    <label for="page-size">Registros por página:</label>
+                    <select id="page-size">
+                        <option value="10" selected>10</option>
+                        <option value="25">25</option>
+                        <option value="50">50</option>
+                        <option value="100">100</option>
+                    </select>
+                </div>
+            </div>
         </div>
     </main>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const API_URL = '<?php echo API_BASE_URL; ?>apertura_cierre.php';
+    const tbody = document.getElementById('apertura-cierre-tbody');
+    const filterForm = document.getElementById('filter-form');
+    const paginationControls = document.getElementById('pagination-controls');
+    const pageSizeSelector = document.getElementById('page-size');
+
+    let currentPage = 1;
+
+    async function fetchRegistros() {
+        const pageSize = pageSizeSelector.value;
+        const fechaInicio = document.getElementById('fecha_inicio').value;
+        const fechaFin = document.getElementById('fecha_fin').value;
+        const tipoMovimiento = document.getElementById('tipo_movimiento').value;
+
+        let queryParams = `?page=${currentPage}&page_size=${pageSize}`;
+        if (fechaInicio) queryParams += `&fecha_inicio=${fechaInicio}`;
+        if (fechaFin) queryParams += `&fecha_fin=${fechaFin}`;
+        if (tipoMovimiento) queryParams += `&tipo_movimiento=${tipoMovimiento}`;
+
+        try {
+            const response = await fetch(API_URL + queryParams);
+            if (!response.ok) {
+                if (response.status === 404) {
+                    tbody.innerHTML = '<tr><td colspan="6">No se encontraron registros.</td></tr>';
+                    updatePagination(null);
+                } else {
+                    throw new Error('Error en la respuesta de la red: ' + response.statusText);
+                }
+                return;
+            }
+
+            const data = await response.json();
+            renderTable(data.records);
+            updatePagination(data.pagination);
+
+        } catch (error) {
+            console.error('Error al obtener los registros:', error);
+            tbody.innerHTML = '<tr><td colspan="6">Error al cargar los datos. Por favor, intente de nuevo.</td></tr>';
+        }
+    }
+
+    function formatDateTime(isoString) {
+        const date = new Date(isoString);
+        const day = String(date.getDate()).padStart(2, '0');
+        const month = String(date.getMonth() + 1).padStart(2, '0'); // Los meses son 0-indexados
+        const year = date.getFullYear();
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${day}/${month}/${year} ${hours}:${minutes}`;
+    }
+
+    function renderTable(registros) {
+        tbody.innerHTML = '';
+        if (!registros || registros.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6">No hay registros que coincidan con los filtros.</td></tr>';
+            return;
+        }
+
+        registros.forEach(reg => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td data-label="Fecha">${formatDateTime(reg.fecha)}</td>
+                <td data-label="Tipo">${reg.tipo_movimiento.charAt(0).toUpperCase() + reg.tipo_movimiento.slice(1)}</td>
+                <td data-label="Importe"><?php echo CURRENCY_SYMBOL; ?>${parseFloat(reg.importe).toFixed(2)}</td>
+                <td data-label="Descripción">${reg.descripcion || ''}</td>
+                <td data-label="Usuario">${reg.usuario_nombre || 'N/A'}</td>
+                <td data-label="Acciones" class="actions-cell">
+                    <a href="apertura_cierre_form.php?id=${reg.id}" class="btn btn-edit">Editar</a>
+                    <button class="btn btn-delete" data-id="${reg.id}">Eliminar</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    function updatePagination(pagination) {
+        paginationControls.innerHTML = '';
+        if (!pagination || pagination.total_pages <= 1) {
+            return;
+        }
+
+        const { page, total_pages } = pagination;
+
+        const prevButton = document.createElement('button');
+        prevButton.innerText = '« Anterior';
+        prevButton.disabled = page <= 1;
+        prevButton.addEventListener('click', () => {
+            if (currentPage > 1) {
+                currentPage--;
+                fetchRegistros();
+            }
+        });
+        paginationControls.appendChild(prevButton);
+
+        for (let i = 1; i <= total_pages; i++) {
+            const pageButton = document.createElement('button');
+            pageButton.innerText = i;
+            pageButton.classList.toggle('active', i === page);
+            pageButton.addEventListener('click', () => {
+                currentPage = i;
+                fetchRegistros();
+            });
+            paginationControls.appendChild(pageButton);
+        }
+
+        const nextButton = document.createElement('button');
+        nextButton.innerText = 'Siguiente »';
+        nextButton.disabled = page >= total_pages;
+        nextButton.addEventListener('click', () => {
+            if (currentPage < total_pages) {
+                currentPage++;
+                fetchRegistros();
+            }
+        });
+        paginationControls.appendChild(nextButton);
+    }
+
+    filterForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        currentPage = 1;
+        fetchRegistros();
+    });
+
+    pageSizeSelector.addEventListener('change', function() {
+        currentPage = 1;
+        fetchRegistros();
+    });
+
+    tbody.addEventListener('click', function(e) {
+        if (e.target.classList.contains('btn-delete')) {
+            const registroId = e.target.getAttribute('data-id');
+            if (confirm('¿Estás seguro de que quieres eliminar este registro?')) {
+                deleteRegistro(registroId);
+            }
+        }
+    });
+
+    async function deleteRegistro(id) {
+        try {
+            const response = await fetch(`${API_URL}?id=${id}`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' }
+            });
+
+            const result = await response.json();
+
+            if (response.ok) {
+                alert(result.message || 'Registro eliminado con éxito.');
+                fetchRegistros();
+            } else {
+                alert('Error al eliminar: ' + (result.message || 'Error desconocido'));
+            }
+
+        } catch (error) {
+            console.error('Error al eliminar:', error);
+            alert('Ocurrió un error de red al intentar eliminar el registro.');
+        }
+    }
+
+    // Carga inicial
+    fetchRegistros();
+});
+</script>
+
+<style>
+.pagination-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1rem;
+}
+#pagination-controls button {
+    margin: 0 2px;
+}
+#pagination-controls button.active {
+    font-weight: bold;
+    background-color: #007bff;
+    color: white;
+}
+.filter-container .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+.filter-container .filters input,
+.filter-container .filters select,
+.filter-container .filters button {
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+.filter-container .filters input[type="date"] {
+    width: auto;
+    padding: 8px;
+}
+.filter-container .filters select {
+    width: 150px;
+    padding: 8px;
+}
+</style>

--- a/frontend_web/apertura_cierre_form.php
+++ b/frontend_web/apertura_cierre_form.php
@@ -1,0 +1,90 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+include_once 'templates/header.php';
+include_once __DIR__ . '/config.php';
+
+// Función auxiliar para obtener datos de la API
+function getAPIData($endpoint) {
+    $api_url = API_BASE_URL . $endpoint;
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($httpcode >= 400) {
+        return null;
+    }
+    return json_decode($response, true);
+}
+
+$is_editing = false;
+$registro_data = null;
+$page_title = 'Registrar Apertura o Cierre';
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $registro_id = intval($_GET['id']);
+    $page_title = 'Editar Registro';
+    $registro_data = getAPIData("apertura_cierre.php?id=$registro_id");
+
+    // Formatear la fecha para el input type="datetime-local"
+    if ($registro_data && !empty($registro_data['fecha'])) {
+        $registro_data['fecha'] = (new DateTime($registro_data['fecha']))->format('Y-m-d\TH:i');
+    }
+}
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo htmlspecialchars($page_title); ?></h1>
+                <a href="apertura_cierre.php" class="btn btn-secondary">Volver a Lista</a>
+            </div>
+
+            <?php if (isset($_GET['error'])): ?>
+                <p class="error-message"><?php echo htmlspecialchars(urldecode($_GET['error'])); ?></p>
+            <?php endif; ?>
+
+            <div class="form-container">
+                <form action="apertura_cierre_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($registro_data['id'] ?? ''); ?>">
+                    <input type="hidden" name="action" value="<?php echo $is_editing ? 'update' : 'create'; ?>">
+
+                    <div class="form-group">
+                        <label for="fecha">Fecha y Hora</label>
+                        <input type="datetime-local" id="fecha" name="fecha" value="<?php echo htmlspecialchars($registro_data['fecha'] ?? date('Y-m-d\TH:i')); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="tipo_movimiento">Tipo de Movimiento</label>
+                        <select id="tipo_movimiento" name="tipo_movimiento" required>
+                            <option value="apertura" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'apertura') ? 'selected' : ''; ?>>Apertura</option>
+                            <option value="cierre" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'cierre') ? 'selected' : ''; ?>>Cierre</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="importe">Importe</label>
+                        <input type="number" id="importe" name="importe" step="0.01" min="0.01" value="<?php echo htmlspecialchars($registro_data['importe'] ?? ''); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="descripcion">Descripción</label>
+                        <textarea id="descripcion" name="descripcion" rows="4"><?php echo htmlspecialchars($registro_data['descripcion'] ?? ''); ?></textarea>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar Registro' : 'Guardar Registro'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>

--- a/frontend_web/apertura_cierre_handler.php
+++ b/frontend_web/apertura_cierre_handler.php
@@ -1,0 +1,73 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php?error=Por+favor+inicie+sesión');
+    exit();
+}
+
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    require_once 'config.php';
+    $action = $_POST['action'] ?? '';
+    $api_url = API_BASE_URL . 'apertura_cierre.php';
+
+    $data = [
+        'fecha' => $_POST['fecha'] ?? '',
+        'tipo_movimiento' => $_POST['tipo_movimiento'] ?? '',
+        'importe' => $_POST['importe'] ?? '',
+        'descripcion' => $_POST['descripcion'] ?? '',
+        'usuario_id' => $_SESSION['user_id']
+    ];
+
+    // Cerramos la sesión para evitar bloqueos. La API la reabrirá.
+    session_write_close();
+
+    $ch = curl_init();
+
+    // Para que la API pueda acceder a la sesión, debemos pasar el ID de sesión
+    curl_setopt($ch, CURLOPT_COOKIE, "PHPSESSID=" . $_COOKIE['PHPSESSID']);
+
+    if ($action == 'create') {
+        curl_setopt($ch, CURLOPT_URL, $api_url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    } elseif ($action == 'update') {
+        $data['id'] = $_POST['id'];
+        curl_setopt($ch, CURLOPT_URL, $api_url);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    } else {
+        header('Location: apertura_cierre.php?error=Acción no válida');
+        exit();
+    }
+
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($http_code == 200 || $http_code == 201) {
+        $success_message = ($action == 'create') ? 'Registro guardado con éxito.' : 'Registro actualizado con éxito.';
+        header('Location: apertura_cierre.php?success=' . urlencode($success_message));
+    } else {
+        $error_data = json_decode($response, true);
+        $error_message = $error_data['message'] ?? 'Ocurrió un error en la operación.';
+        // Redirigir de vuelta al formulario con el error
+        $redirect_url = 'apertura_cierre_form.php?error=' . urlencode($error_message);
+        if ($action == 'update' && !empty($_POST['id'])) {
+            $redirect_url .= '&id=' . $_POST['id'];
+        }
+        header('Location: ' . $redirect_url);
+    }
+    exit();
+
+} else {
+    header('Location: apertura_cierre.php');
+    exit();
+}
+?>


### PR DESCRIPTION
Se añade una nueva funcionalidad para la gestión de aperturas y cierres de caja en la página `apertura_cierre.php`.

Esta implementación es un clon funcional de `movim_caja.php` pero con una regla de negocio clave: solo se permite un registro de 'Apertura' y uno de 'Cierre' por día.

Cambios incluidos:
- Nuevo script de migración para crear la tabla `apertura_cierre_caja` con una restricción `UNIQUE` en la fecha y el tipo de movimiento.
- Nuevo modelo `AperturaCierre.php` que maneja las operaciones de la base de datos y los errores de la restricción de unicidad.
- Nuevo endpoint de API `apertura_cierre.php` para las operaciones CRUD.
- Nuevos archivos de frontend (`apertura_cierre.php`, `apertura_cierre_form.php`, `apertura_cierre_handler.php`) adaptados para la nueva funcionalidad.