### PR TITLE
feat: Restrict operations on closed dates in movim_caja.php

### DIFF
--- a/backend/api/v1/apertura_cierre.php
+++ b/backend/api/v1/apertura_cierre.php
@@ -26,6 +26,9 @@ switch ($request_method) {
                 http_response_code(404);
                 echo json_encode(["message" => "Registro no encontrado."]);
             }
+        } else if (isset($_GET['action']) && $_GET['action'] == 'is_date_closed' && isset($_GET['fecha'])) {
+            $is_closed = $aperturaCierre->isDateClosed($_GET['fecha']);
+            echo json_encode(['is_closed' => $is_closed]);
         } else {
             $filters = [
                 'fecha_inicio' => $_GET['fecha_inicio'] ?? null,

--- a/backend/models/AperturaCierre.php
+++ b/backend/models/AperturaCierre.php
@@ -133,5 +133,15 @@ class AperturaCierre {
         }
         return false;
     }
+
+    public function isDateClosed($fecha) {
+        $query = "SELECT COUNT(*) as count FROM " . $this->table_name . " WHERE fecha_movimiento = :fecha AND tipo_movimiento = 'cierre'";
+        $stmt = $this->conn->prepare($query);
+        $fecha_movimiento = date('Y-m-d', strtotime($fecha));
+        $stmt->bindParam(':fecha', $fecha_movimiento);
+        $stmt->execute();
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row['count'] > 0;
+    }
 }
 ?>

--- a/frontend_web/movim_caja.php
+++ b/frontend_web/movim_caja.php
@@ -77,11 +77,35 @@ include_once __DIR__ . '/config.php';
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const API_URL = '<?php echo API_BASE_URL; ?>movimientos_caja.php';
+    const API_URL_CIERRE = '<?php echo API_BASE_URL; ?>apertura_cierre.php';
     const tbody = document.getElementById('movimientos-tbody');
     const filterForm = document.getElementById('filter-form');
     const paginationControls = document.getElementById('pagination-controls');
     const pageSizeSelector = document.getElementById('page-size');
+    const newMovementBtn = document.querySelector('a[href="movimiento_caja_form.php"]');
     let currentPage = 1;
+
+    async function checkIfDateIsClosed(date) {
+        try {
+            const response = await fetch(`${API_URL_CIERRE}?action=is_date_closed&fecha=${date}`);
+            const data = await response.json();
+            return data.is_closed;
+        } catch (error) {
+            console.error('Error al verificar si la fecha está cerrada:', error);
+            return true;
+        }
+    }
+
+    newMovementBtn.addEventListener('click', async function(e) {
+        e.preventDefault();
+        const today = new Date().toISOString().slice(0, 10);
+        const isClosed = await checkIfDateIsClosed(today);
+        if (isClosed) {
+            alert('La fecha está cerrada y no se pueden registrar nuevos movimientos.');
+        } else {
+            window.location.href = this.href;
+        }
+    });
 
     async function fetchMovimientos() {
         const pageSize = pageSizeSelector.value;
@@ -122,6 +146,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         movimientos.forEach(mov => {
             const tr = document.createElement('tr');
+            tr.dataset.fecha = mov.fecha.split(' ')[0];
             const importeClass = mov.tipo_movimiento === 'entrada' ? 'text-success' : 'text-danger';
             const importeSign = mov.tipo_movimiento === 'entrada' ? '+' : '-';
 
@@ -187,9 +212,30 @@ document.addEventListener('DOMContentLoaded', function() {
         fetchMovimientos();
     });
 
-    tbody.addEventListener('click', (e) => {
-        if (e.target.classList.contains('btn-delete')) {
-            const movimientoId = e.target.getAttribute('data-id');
+    tbody.addEventListener('click', async (e) => {
+        const target = e.target;
+        const tr = target.closest('tr');
+        if (!tr) return;
+
+        const fechaMovimiento = tr.dataset.fecha;
+
+        if (target.classList.contains('btn-edit')) {
+            e.preventDefault();
+            const isClosed = await checkIfDateIsClosed(fechaMovimiento);
+            if (isClosed) {
+                alert('La fecha está cerrada y no se puede editar el movimiento.');
+            } else {
+                window.location.href = target.href;
+            }
+        }
+
+        if (target.classList.contains('btn-delete')) {
+            const movimientoId = target.getAttribute('data-id');
+            const isClosed = await checkIfDateIsClosed(fechaMovimiento);
+            if (isClosed) {
+                alert('La fecha está cerrada y no se puede eliminar el movimiento.');
+                return;
+            }
             if (confirm('¿Estás seguro de que quieres eliminar este movimiento?')) {
                 deleteMovimiento(movimientoId);
             }


### PR DESCRIPTION
This commit introduces a validation mechanism to prevent creating, editing, or deleting cash movements on dates that have a 'cierre' (closing) record in the `apertura_cierre_caja` table.

- Added `isDateClosed` method to the `AperturaCierre` model to check if a date is closed.
- Extended the `apertura_cierre` API with an `is_date_closed` action to expose this functionality to the frontend.
- Modified `movim_caja.php` to use this new API endpoint to validate dates before performing create, edit, or delete operations.
- If a date is closed, a JavaScript alert is shown to the user, and the action is prevented.