### PR TITLE
feat: Add validation to movement form for closed dates

### DIFF
--- a/frontend_web/movimiento_caja_form.php
+++ b/frontend_web/movimiento_caja_form.php
@@ -86,3 +86,65 @@ if (isset($_GET['id'])) {
         </div>
     </main>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const API_URL_CIERRE = '<?php echo API_BASE_URL; ?>apertura_cierre.php';
+    const fechaInput = document.getElementById('fecha');
+    const form = document.querySelector('form');
+    const submitButton = form.querySelector('button[type="submit"]');
+    const isEditing = <?php echo json_encode($is_editing); ?>;
+
+    async function checkIfDateIsClosed(date) {
+        if (!date) return false;
+        try {
+            const response = await fetch(`${API_URL_CIERRE}?action=is_date_closed&fecha=${date}`);
+            const data = await response.json();
+            return data.is_closed;
+        } catch (error) {
+            console.error('Error al verificar si la fecha está cerrada:', error);
+            return true; // Asumir que está cerrada si hay un error
+        }
+    }
+
+    function toggleSubmitButton(enabled, message = '') {
+        submitButton.disabled = !enabled;
+        let errorDiv = document.getElementById('fecha-error-message');
+        if (!errorDiv) {
+            errorDiv = document.createElement('div');
+            errorDiv.id = 'fecha-error-message';
+            errorDiv.style.color = 'red';
+            errorDiv.style.marginTop = '5px';
+            fechaInput.parentNode.appendChild(errorDiv);
+        }
+        errorDiv.textContent = message;
+    }
+
+    async function validateDate() {
+        const fechaValue = fechaInput.value.split('T')[0];
+        const isClosed = await checkIfDateIsClosed(fechaValue);
+        if (isClosed) {
+            toggleSubmitButton(false, 'La fecha seleccionada está cerrada y no se pueden realizar cambios.');
+        } else {
+            toggleSubmitButton(true);
+        }
+    }
+
+    if (!isEditing) {
+        fechaInput.addEventListener('change', validateDate);
+        validateDate(); // Validar la fecha inicial al cargar
+    }
+
+    form.addEventListener('submit', async function(e) {
+        if (isEditing) return; // No validar en modo edición desde aquí
+
+        const fechaValue = fechaInput.value.split('T')[0];
+        const isClosed = await checkIfDateIsClosed(fechaValue);
+
+        if (isClosed) {
+            e.preventDefault();
+            alert('La fecha está cerrada y no se puede guardar el movimiento.');
+            toggleSubmitButton(false, 'La fecha seleccionada está cerrada y no se pueden realizar cambios.');
+        }
+    });
+});
+</script>


### PR DESCRIPTION
This commit enhances the feature by adding a validation check to the `movimiento_caja_form.php` page.

- When creating a new movement, the form now checks if the selected date is closed.
- If the date is closed, an error message is displayed, and the form cannot be submitted.
- This validation is triggered both when the date is changed and on form submission.