### PR TITLE
feat: Add server-side validation and hide action buttons

### DIFF
--- a/backend/api/v1/movimientos_caja.php
+++ b/backend/api/v1/movimientos_caja.php
@@ -10,8 +10,10 @@ session_start();
 include_once __DIR__ . '/../../config/app_config.php';
 include_once __DIR__ . '/../../core/Database.php';
 include_once __DIR__ . '/../../models/MovimientoCaja.php';
+include_once __DIR__ . '/../../models/AperturaCierre.php';
 
 $movimientoCaja = new MovimientoCaja();
+$aperturaCierre = new AperturaCierre();
 $request_method = $_SERVER["REQUEST_METHOD"];
 
 switch ($request_method) {
@@ -39,6 +41,11 @@ switch ($request_method) {
     case 'POST':
         $data = json_decode(file_get_contents("php://input"));
         if (!empty($data->fecha) && !empty($data->tipo_movimiento) && isset($data->importe) && isset($_SESSION['user_id'])) {
+            if ($aperturaCierre->isDateClosed($data->fecha)) {
+                http_response_code(403);
+                echo json_encode(["message" => "La fecha seleccionada está cerrada. No se pueden agregar nuevos movimientos."]);
+                break;
+            }
             $new_id = $movimientoCaja->create($data->fecha, $data->tipo_movimiento, $data->importe, $data->descripcion ?? '', $_SESSION['user_id']);
             if ($new_id) {
                 http_response_code(201);
@@ -56,6 +63,17 @@ switch ($request_method) {
     case 'PUT':
         $data = json_decode(file_get_contents("php://input"));
         if (!empty($data->id) && !empty($data->fecha) && !empty($data->tipo_movimiento) && isset($data->importe)) {
+            $movimiento_actual = $movimientoCaja->readOne($data->id);
+            if (!$movimiento_actual) {
+                http_response_code(404);
+                echo json_encode(["message" => "Movimiento no encontrado."]);
+                break;
+            }
+            if ($aperturaCierre->isDateClosed($movimiento_actual['fecha'])) {
+                http_response_code(403);
+                echo json_encode(["message" => "La fecha del movimiento original está cerrada. No se puede actualizar."]);
+                break;
+            }
             if ($movimientoCaja->update($data->id, $data->fecha, $data->tipo_movimiento, $data->importe, $data->descripcion ?? '')) {
                 http_response_code(200);
                 echo json_encode(["message" => "Movimiento actualizado."]);
@@ -72,6 +90,17 @@ switch ($request_method) {
     case 'DELETE':
         if (!empty($_GET["id"])) {
             $id = intval($_GET["id"]);
+            $movimiento_actual = $movimientoCaja->readOne($id);
+            if (!$movimiento_actual) {
+                http_response_code(404);
+                echo json_encode(["message" => "Movimiento no encontrado."]);
+                break;
+            }
+            if ($aperturaCierre->isDateClosed($movimiento_actual['fecha'])) {
+                http_response_code(403);
+                echo json_encode(["message" => "La fecha del movimiento está cerrada. No se puede eliminar."]);
+                break;
+            }
             if ($movimientoCaja->delete($id)) {
                 http_response_code(200);
                 echo json_encode(["message" => "Movimiento eliminado."]);

--- a/backend/models/MovimientoCaja.php
+++ b/backend/models/MovimientoCaja.php
@@ -10,7 +10,8 @@ class MovimientoCaja {
     }
 
     public function readAll($filters = [], $page = 1, $page_size = 10) {
-        $query = "SELECT m.id, m.fecha, m.tipo_movimiento, m.importe, m.descripcion, m.usuario_id, u.nombre_completo as usuario_nombre
+        $query = "SELECT m.id, m.fecha, m.tipo_movimiento, m.importe, m.descripcion, m.usuario_id, u.nombre_completo as usuario_nombre,
+                         (SELECT COUNT(*) FROM apertura_cierre_caja acc WHERE acc.fecha_movimiento = DATE(m.fecha) AND acc.tipo_movimiento = 'cierre') > 0 as is_closed
                   FROM " . $this->table_name . " m
                   LEFT JOIN usuarios u ON m.usuario_id = u.id";
         $where_clauses = [];

--- a/frontend_web/movim_caja.php
+++ b/frontend_web/movim_caja.php
@@ -150,6 +150,14 @@ document.addEventListener('DOMContentLoaded', function() {
             const importeClass = mov.tipo_movimiento === 'entrada' ? 'text-success' : 'text-danger';
             const importeSign = mov.tipo_movimiento === 'entrada' ? '+' : '-';
 
+            let actionButtons = '';
+            if (!mov.is_closed) {
+                actionButtons = `
+                    <a href="movimiento_caja_form.php?id=${mov.id}" class="btn btn-edit">Editar</a>
+                    <button class="btn btn-delete" data-id="${mov.id}">Eliminar</button>
+                `;
+            }
+
             tr.innerHTML = `
                 <td data-label="Fecha">${formatDateTime(mov.fecha)}</td>
                 <td data-label="Tipo">${mov.tipo_movimiento.charAt(0).toUpperCase() + mov.tipo_movimiento.slice(1)}</td>
@@ -157,8 +165,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 <td data-label="Descripción">${mov.descripcion || ''}</td>
                 <td data-label="Usuario">${mov.usuario_nombre || 'N/A'}</td>
                 <td data-label="Acciones" class="actions-cell">
-                    <a href="movimiento_caja_form.php?id=${mov.id}" class="btn btn-edit">Editar</a>
-                    <button class="btn btn-delete" data-id="${mov.id}">Eliminar</button>
+                    ${actionButtons}
                 </td>
             `;
             tbody.appendChild(tr);
@@ -212,30 +219,9 @@ document.addEventListener('DOMContentLoaded', function() {
         fetchMovimientos();
     });
 
-    tbody.addEventListener('click', async (e) => {
-        const target = e.target;
-        const tr = target.closest('tr');
-        if (!tr) return;
-
-        const fechaMovimiento = tr.dataset.fecha;
-
-        if (target.classList.contains('btn-edit')) {
-            e.preventDefault();
-            const isClosed = await checkIfDateIsClosed(fechaMovimiento);
-            if (isClosed) {
-                alert('La fecha está cerrada y no se puede editar el movimiento.');
-            } else {
-                window.location.href = target.href;
-            }
-        }
-
-        if (target.classList.contains('btn-delete')) {
-            const movimientoId = target.getAttribute('data-id');
-            const isClosed = await checkIfDateIsClosed(fechaMovimiento);
-            if (isClosed) {
-                alert('La fecha está cerrada y no se puede eliminar el movimiento.');
-                return;
-            }
+    tbody.addEventListener('click', (e) => {
+        if (e.target.classList.contains('btn-delete')) {
+            const movimientoId = e.target.getAttribute('data-id');
             if (confirm('¿Estás seguro de que quieres eliminar este movimiento?')) {
                 deleteMovimiento(movimientoId);
             }


### PR DESCRIPTION
This commit introduces robust server-side validation and improves the UI by hiding action buttons for cash movements on closed dates.

- Added server-side checks in the `movimientos_caja` API to prevent creating, updating, or deleting movements on closed dates. The API now returns a 403 Forbidden error if the rule is violated.
- The `MovimientoCaja` model's `readAll` method now includes an `is_closed` flag with each movement record.
- The frontend `movim_caja.php` page uses this flag to hide the 'Edit' and 'Delete' buttons for movements on closed dates, improving user experience.
- The `movimiento_caja_form.php` retains its frontend validation for a better UX when creating new movements.