### PR TITLE
feat: Add styled, dynamic filters to caja.php

### DIFF
--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -179,7 +179,25 @@ document.addEventListener('DOMContentLoaded', function() {
     const today = new Date();
     yearSelect.value = today.getFullYear();
     monthSelect.value = today.getMonth() + 1;
+    statusSelect.value = 'completado'; // Estado por defecto
     updateDateFields();
     fetchOrders(); // Carga inicial
 });
 </script>
+
+<style>
+.filter-container .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    align-items: center;
+    padding-bottom: 20px;
+}
+.filter-container .filters select,
+.filter-container .filters input,
+.filter-container .filters button {
+    padding: 8px 12px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+}
+</style>


### PR DESCRIPTION
This commit implements a new filter section on the `caja.php` page, allowing users to filter orders by year, month, date range, and status.

- **Frontend (`caja.php`):**
  - Replaced the static PHP order rendering with a dynamic JavaScript implementation.
  - Added a new filter bar with dropdowns for Year, Month, and Status, and inputs for a date range.
  - The JavaScript now populates the filters, handles user interactions, and fetches/renders order data from the API.
  - The date range inputs are automatically updated when the user selects a year and month.
  - The status filter now defaults to 'Completado' on page load.
  - Added CSS to style the filters in a clean, horizontal layout using Flexbox.

- **Backend (`pedidos.php` API):**
  - The API has been updated to accept `start_date` and `end_date` query parameters.
  - It now filters the orders by the specified date range on the server before returning the results.