### PR TITLE
feat: Add and style dynamic filters on Caja page

### DIFF
--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
     exit();
 }
 
-$page_title = 'Pedidos Finalizados';
+$page_title = 'Caja - Pedidos';
 include_once 'templates/header.php';
 include_once __DIR__ . '/config.php';
 ?>
@@ -17,7 +17,7 @@ include_once __DIR__ . '/config.php';
     <main class="main-content">
         <div class="container">
             <div class="page-header">
-                <h1>Pedidos Completados y Cancelados</h1>
+                <h1>Caja - Pedidos</h1>
                 <a href="pedido_form.php?view=caja_create" class="btn">Crear Pedido Nuevo</a>
             </div>
 
@@ -189,15 +189,25 @@ document.addEventListener('DOMContentLoaded', function() {
 .filter-container .filters {
     display: flex;
     flex-wrap: wrap;
-    gap: 15px;
+    gap: 10px;
     align-items: center;
     padding-bottom: 20px;
 }
 .filter-container .filters select,
-.filter-container .filters input,
-.filter-container .filters button {
-    padding: 8px 12px;
+.filter-container .filters input {
+    padding: 8px;
     border-radius: 5px;
     border: 1px solid #ccc;
+    flex-grow: 1;
+    flex-basis: 150px; /* Base width before growing/shrinking */
+}
+.filter-container .filters button {
+    padding: 8px 15px;
+    border-radius: 5px;
+    border: 1px solid #007bff;
+    background-color: #007bff;
+    color: white;
+    cursor: pointer;
+    flex-grow: 0;
 }
 </style>


### PR DESCRIPTION
This commit implements a new, styled filter section on the `caja.php` page and changes the page title as requested.

- **Frontend (`caja.php`):**
  - The page title has been changed to "Caja - Pedidos".
  - A new filter bar with dropdowns for Year, Month, Status, and date range inputs has been added.
  - The page is now fully dynamic, using JavaScript to fetch and render order data from the API.
  - The status filter defaults to 'Completado' on page load.
  - Improved CSS has been added to style the filters in a clean, horizontal, and responsive layout.

- **Backend (`pedidos.php` API):**
  - The API has been updated to accept `start_date` and `end_date` to filter orders by date range.