### PR TITLE
feat: Add and style dynamic filters on Caja page with date formatting

### DIFF
--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -123,6 +123,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    function formatCustomDateTime(isoString) {
+        const date = new Date(isoString);
+        const day = String(date.getDate()).padStart(2, '0');
+        const month = String(date.getMonth() + 1).padStart(2, '0'); // Los meses son 0-indexados
+        const year = date.getFullYear();
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${day}/${month}/${year} ${hours}:${minutes}`;
+    }
+
     function renderOrders(orders) {
         orderCardsContainer.innerHTML = '';
         if (!orders || orders.length === 0) {
@@ -154,7 +164,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 <div class="card-body">
                     <p><strong>Mesa:</strong> ${order.numero_mesa || 'N/A'}</p>
                     <p><strong>Mozo:</strong> ${order.nombre_mozo || 'N/A'}</p>
-                    <p><strong>Fecha:</strong> ${new Date(order.fecha_creacion).toLocaleString('es-ES')}</p>
+                    <p><strong>Fecha:</strong> ${formatCustomDateTime(order.fecha_creacion)}</p>
                     <p class="total"><strong>Total:</strong> <?php echo CURRENCY_SYMBOL; ?>${parseFloat(order.total).toFixed(2)}</p>
                 </div>
                 <div class="card-footer">


### PR DESCRIPTION
This commit implements a new, styled filter section on the `caja.php` page, changes the page title, and formats the date on the order cards as requested.

- **Frontend (`caja.php`):**
  - The page title has been changed to "Caja - Pedidos".
  - A new filter bar with dropdowns for Year, Month, Status, and date range inputs has been added.
  - The page is now fully dynamic, using JavaScript to fetch and render order data from the API.
  - The status filter defaults to 'Completado' on page load.
  - Improved CSS has been added to style the filters in a clean, horizontal, and responsive layout.
  - A new JavaScript function `formatCustomDateTime` has been added to format the order date as `dd/MM/yyyy HH:mm`.

- **Backend (`pedidos.php` API):**
  - The API has been updated to accept `start_date` and `end_date` to filter orders by date range.