### PR TITLE
feat: Implementar módulo de ventas y corregir filtro de series

### DIFF
--- a/backend/api/v1/series_documentos.php
+++ b/backend/api/v1/series_documentos.php
@@ -21,7 +21,24 @@ switch ($request_method) {
                 http_response_code(404);
                 echo json_encode(["message" => "Serie no encontrada."]);
             }
+        } else if (!empty($_GET["id_tipo_documento"])) {
+            // Listar series por tipo de documento
+            $id_tipo_documento = intval($_GET["id_tipo_documento"]);
+            $stmt = $serieDocumento->readByTipoDocumento($id_tipo_documento);
+            $num = $stmt->rowCount();
+            if ($num > 0) {
+                $series_arr = ["records" => []];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    array_push($series_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($series_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode(["records" => []]);
+            }
         } else {
+            // Listar todas las series (comportamiento original)
             $stmt = $serieDocumento->readAll();
             $num = $stmt->rowCount();
             if ($num > 0) {

--- a/backend/models/SerieDocumento.php
+++ b/backend/models/SerieDocumento.php
@@ -15,6 +15,15 @@ class SerieDocumento {
         return $stmt;
     }
 
+    public function readByTipoDocumento($id_tipo_documento) {
+        // Usamos una consulta directa para evitar modificar el SP existente
+        $query = "SELECT id, serie FROM series_documentos WHERE id_tipo_documento = :id_tipo_documento AND estado = 1 ORDER BY serie ASC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id_tipo_documento', $id_tipo_documento, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt;
+    }
+
     public function readOne($id) {
         $query = "CALL sp_getOneSerie(:id)";
         $stmt = $this->conn->prepare($query);


### PR DESCRIPTION
Añade la funcionalidad completa para la gestión de ventas (boletas/facturas) y corrige un error en el filtrado de series de documentos.

Características principales:
- Generación automática de un documento de venta cuando un pedido 'completado' es pagado.
- El estado del pedido se actualiza a 'pagado' después de la transacción.
- Creación de la página `ventas.php` que muestra una grilla con todas las ventas.
- Al seleccionar una serie, se obtiene y muestra automáticamente el siguiente número de documento correlativo.
- **Corrección:** El combo de series ahora se filtra correctamente según el tipo de documento (Boleta/Factura) seleccionado.
- Creación de los endpoints de API necesarios para el módulo.
- Definición del nuevo esquema de base de datos en `esquema_ventas.sql`.