### PR TITLE
Feat: Implement sale voiding functionality

### DIFF
--- a/backend/api/v1/anular_venta.php
+++ b/backend/api/v1/anular_venta.php
@@ -1,0 +1,60 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: POST");
+header("Access-Control-Max-Age: 3600");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../config/database.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(["message" => "Método no permitido."]);
+    exit;
+}
+
+$data = json_decode(file_get_contents("php://input"));
+
+if (empty($data->id_venta)) {
+    http_response_code(400);
+    echo json_encode(["message" => "ID de venta no proporcionado."]);
+    exit;
+}
+
+$id_venta = intval($data->id_venta);
+
+try {
+    $pdo = new PDO(DB_DSN, DB_USER, DB_PASS);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    $stmt = $pdo->prepare("UPDATE ventas SET estado = 'anulada' WHERE id = :id_venta AND estado = 'emitida'");
+    $stmt->bindParam(':id_venta', $id_venta, PDO::PARAM_INT);
+
+    $stmt->execute();
+
+    if ($stmt->rowCount() > 0) {
+        http_response_code(200);
+        echo json_encode(["message" => "Venta anulada con éxito."]);
+    } else {
+        // Check if the sale exists and was already voided or not in 'emitida' state
+        $checkStmt = $pdo->prepare("SELECT estado FROM ventas WHERE id = :id_venta");
+        $checkStmt->bindParam(':id_venta', $id_venta, PDO::PARAM_INT);
+        $checkStmt->execute();
+        $result = $checkStmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($result) {
+            http_response_code(409); // Conflict
+            echo json_encode(["message" => "La venta no se pudo anular. Puede que ya esté anulada o en un estado no válido. Estado actual: " . $result['estado']]);
+        } else {
+            http_response_code(404); // Not Found
+            echo json_encode(["message" => "Venta no encontrada."]);
+        }
+    }
+
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(["message" => "Error al anular la venta: " . $e->getMessage()]);
+} finally {
+    $pdo = null;
+}
+?>

--- a/frontend_web/ventas.php
+++ b/frontend_web/ventas.php
@@ -136,7 +136,7 @@ $ventas_data = getVentas($filters);
                                     <td data-label="Acciones" class="actions-cell">
                                         <a href="venta_form.php?id=<?php echo $venta['id']; ?>" class="btn btn-sm btn-edit">Ver</a>
                                         <?php if ($venta['estado'] === 'emitida'): ?>
-                                            <a href="venta_anular_handler.php?id=<?php echo $venta['id']; ?>" class="btn btn-sm btn-cancelado" onclick="return confirm('¿Está seguro de que desea anular esta venta?');">Anular</a>
+                                            <button type="button" class="btn btn-sm btn-cancelado btn-anular" data-id="<?php echo $venta['id']; ?>">Anular</button>
                                         <?php endif; ?>
                                     </td>
                                 </tr>
@@ -155,6 +155,7 @@ $ventas_data = getVentas($filters);
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    // Lógica de filtros existente
     const anioSelect = document.getElementById('filtro_anio');
     const mesSelect = document.getElementById('filtro_mes');
     const fechaInicioInput = document.getElementById('fecha_inicio');
@@ -178,8 +179,47 @@ document.addEventListener('DOMContentLoaded', function() {
     anioSelect.addEventListener('change', updateDateFields);
     mesSelect.addEventListener('change', updateDateFields);
 
-    // Al cargar la página, si no hay filtros aplicados, la lógica de PHP ya ha establecido los valores por defecto.
-    // El JS no necesita hacer nada extra.
+    // Lógica para anular venta
+    const anularButtons = document.querySelectorAll('.btn-anular');
+    anularButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const ventaId = this.dataset.id;
+
+            if (confirm('¿Está seguro de que desea anular esta venta?')) {
+                const api_url = '<?php echo API_BASE_URL; ?>' + 'anular_venta.php';
+
+                fetch(api_url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ id_venta: ventaId })
+                })
+                .then(response => response.json().then(data => ({ status: response.status, body: data })))
+                .then(result => {
+                    if (result.status === 200) {
+                        // Actualizar la UI
+                        const row = this.closest('tr');
+                        const statusCell = row.querySelector('.status');
+                        if (statusCell) {
+                            statusCell.classList.remove('status-emitida');
+                            statusCell.classList.add('status-cancelado'); // Re-usando la clase existente
+                            statusCell.textContent = 'Anulada';
+                        }
+                        this.disabled = true;
+                        this.textContent = 'Anulado';
+                        alert(result.body.message);
+                    } else {
+                        throw new Error(result.body.message || 'Error desconocido');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('Error al anular la venta: ' + error.message);
+                });
+            }
+        });
+    });
 });
 </script>
 


### PR DESCRIPTION
- Created a new backend API endpoint `anular_venta.php` to handle the logic for voiding a sale by updating its status to 'anulada' in the database.
- Modified `ventas.php` to change the 'Anular' link into a button that triggers an asynchronous JavaScript call.
- The frontend now dynamically updates the sale's status in the grid upon successful voiding without a page reload.