### PR TITLE
Feat: Add ticket printing functionality for sales receipts

### DIFF
--- a/frontend_web/assets/css/print-ticket.css
+++ b/frontend_web/assets/css/print-ticket.css
@@ -1,0 +1,90 @@
+@media print {
+    /* Ocultar todo por defecto */
+    body * {
+        visibility: hidden;
+    }
+
+    /* Hacer visible solo el contenedor del recibo y su contenido */
+    #printable-receipt, #printable-receipt * {
+        visibility: visible;
+    }
+
+    /* Posicionar el recibo en la esquina superior izquierda de la página */
+    #printable-receipt {
+        position: absolute;
+        left: 0;
+        top: 0;
+        margin: 0;
+        padding: 0;
+        width: 80mm; /* Ancho típico para impresoras de tickets */
+        font-family: 'Courier New', Courier, monospace; /* Fuente de ancho fijo para apariencia de ticket */
+        font-size: 10pt;
+        color: #000;
+    }
+
+    /* Estilos para el contenido del recibo */
+    #printable-receipt .card {
+        border: none;
+        box-shadow: none;
+        margin: 0;
+        padding: 5px;
+    }
+
+    #printable-receipt .card-header h3 {
+        font-size: 12pt;
+        font-weight: bold;
+        text-align: center;
+        margin: 10px 0;
+        width: 100%;
+    }
+
+    #printable-receipt .status {
+        display: none; /* No imprimir el estado en el ticket */
+    }
+
+    #printable-receipt .form-group label {
+        font-size: 9pt;
+        font-weight: bold;
+        margin-bottom: 2px;
+    }
+
+    #printable-receipt .form-group input[readonly] {
+        border: none;
+        background-color: transparent;
+        padding: 1px;
+        font-family: inherit;
+        font-size: 10pt;
+    }
+
+    #printable-receipt .form-group-row {
+        flex-wrap: wrap;
+    }
+
+    #printable-receipt .table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    #printable-receipt .table th,
+    #printable-receipt .table td {
+        padding: 2px;
+        font-size: 9pt;
+        border-bottom: 1px dashed #666;
+    }
+
+    #printable-receipt .table th {
+        text-align: left;
+    }
+
+    #printable-receipt .table tfoot th,
+    #printable-receipt .table tfoot td {
+        font-weight: bold;
+        font-size: 11pt;
+        border-top: 1px solid #000;
+    }
+
+    /* No imprimir botones de acción */
+    .form-actions {
+        display: none;
+    }
+}

--- a/frontend_web/templates/header.php
+++ b/frontend_web/templates/header.php
@@ -9,6 +9,7 @@
     <!-- Main Stylesheet -->
     <link rel="stylesheet" href="assets/css/style.css?v=<?php echo time(); ?>">
     <link rel="stylesheet" href="assets/css/modal.css?v=<?php echo time(); ?>">
+    <link rel="stylesheet" href="assets/css/print-ticket.css?v=<?php echo time(); ?>" media="print">
 </head>
 <body id="page-body">
 <?php include_once __DIR__ . '/modal_alert.php'; ?>

--- a/frontend_web/venta_form.php
+++ b/frontend_web/venta_form.php
@@ -47,106 +47,106 @@ $is_anulada = ($venta_data && $venta_data['estado'] === 'anulada');
                 <h1><?php echo $page_title; ?></h1>
             </div>
 
-            <form id="venta-form" method="POST" action="venta_handler.php?id=<?php echo $venta_id; ?>">
-                <div class="card">
-                    <div class="card-header">
-                        <h3>Datos del Comprobante</h3>
-                        <?php if ($is_editing && isset($venta_data['estado'])): ?>
-                            <span class="status status-<?php echo htmlspecialchars($venta_data['estado']); ?>">
-                                <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $venta_data['estado']))); ?>
-                            </span>
-                        <?php endif; ?>
-                    </div>
-                    <div class="card-body">
-                         <div class="form-group-row">
-                            <div class="form-group" style="flex-grow: 1;">
-                                <label>Tipo de Comprobante</label>
-                                <input type="text" value="<?php echo htmlspecialchars($venta_data['tipo_documento'] ?? ''); ?>" readonly>
-                            </div>
-                            <div class="form-group" style="flex-grow: 1;">
-                                <label>Serie</label>
-                                <input type="text" value="<?php echo htmlspecialchars($venta_data['serie'] ?? ''); ?>" readonly>
-                            </div>
-                            <div class="form-group" style="flex-grow: 1;">
-                                <label>Número</label>
-                                <input type="text" value="<?php echo htmlspecialchars($venta_data['numero_documento'] ?? ''); ?>" readonly>
-                            </div>
-                             <div class="form-group" style="flex-grow: 1;">
-                                <label>Fecha de Emisión</label>
-                                <input type="text" value="<?php echo htmlspecialchars(date("d/m/Y H:i", strtotime($venta_data['fecha_emision']))); ?>" readonly>
+            <div id="printable-receipt">
+                <form id="venta-form" method="POST" action="venta_handler.php?id=<?php echo $venta_id; ?>">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3>Datos del Comprobante</h3>
+                            <?php if ($is_editing && isset($venta_data['estado'])): ?>
+                                <span class="status status-<?php echo htmlspecialchars($venta_data['estado']); ?>">
+                                    <?php echo htmlspecialchars(ucfirst(str_replace('_', ' ', $venta_data['estado']))); ?>
+                                </span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="card-body">
+                            <div class="form-group-row">
+                                <div class="form-group" style="flex-grow: 1;">
+                                    <label>Tipo de Comprobante</label>
+                                    <input type="text" value="<?php echo htmlspecialchars($venta_data['tipo_documento'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group" style="flex-grow: 1;">
+                                    <label>Serie</label>
+                                    <input type="text" value="<?php echo htmlspecialchars($venta_data['serie'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group" style="flex-grow: 1;">
+                                    <label>Número</label>
+                                    <input type="text" value="<?php echo htmlspecialchars($venta_data['numero_documento'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group" style="flex-grow: 1;">
+                                    <label>Fecha de Emisión</label>
+                                    <input type="text" value="<?php echo htmlspecialchars(date("d/m/Y H:i", strtotime($venta_data['fecha_emision']))); ?>" readonly>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
 
-                <div class="card mt-4">
-                    <div class="card-header">
-                        <h3>Datos del Cliente</h3>
-                    </div>
-                    <div class="card-body">
-                        <div class="form-group">
-                            <label>Nombre del Cliente</label>
-                            <input type="text" value="<?php echo htmlspecialchars($venta_data['nombre_cliente'] ?? 'Varios'); ?>" readonly>
+                    <div class="card mt-4">
+                        <div class="card-header">
+                            <h3>Datos del Cliente</h3>
                         </div>
-                        <div class="form-group-row">
-                            <div class="form-group" style="flex-grow: 2;">
-                                <label>RUC / DNI</label>
-                                <input type="text" value="<?php echo htmlspecialchars($venta_data['ruc_cliente'] ?? ''); ?>" readonly>
+                        <div class="card-body">
+                            <div class="form-group">
+                                <label>Nombre del Cliente</label>
+                                <input type="text" value="<?php echo htmlspecialchars($venta_data['nombre_cliente'] ?? 'Varios'); ?>" readonly>
                             </div>
-                            <div class="form-group" style="flex-grow: 3;">
-                                <label>Dirección</label>
-                                <input type="text" value="<?php echo htmlspecialchars($venta_data['direccion_cliente'] ?? ''); ?>" readonly>
+                            <div class="form-group-row">
+                                <div class="form-group" style="flex-grow: 2;">
+                                    <label>RUC / DNI</label>
+                                    <input type="text" value="<?php echo htmlspecialchars($venta_data['ruc_cliente'] ?? ''); ?>" readonly>
+                                </div>
+                                <div class="form-group" style="flex-grow: 3;">
+                                    <label>Dirección</label>
+                                    <input type="text" value="<?php echo htmlspecialchars($venta_data['direccion_cliente'] ?? ''); ?>" readonly>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
 
-                <div class="card mt-4">
-                    <div class="card-header">
-                        <h3>Detalle de la Venta</h3>
-                    </div>
-                    <div class="card-body">
-                        <div class="table-responsive">
-                            <table class="table">
-                                <thead>
-                                    <tr>
-                                        <th>Producto</th>
-                                        <th>Cantidad</th>
-                                        <th>Precio Unit.</th>
-                                        <th>Subtotal</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <?php if (!empty($venta_data['items'])): ?>
-                                        <?php foreach ($venta_data['items'] as $item): ?>
+                    <div class="card mt-4">
+                        <div class="card-header">
+                            <h3>Detalle de la Venta</h3>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive">
+                                <table class="table">
+                                    <thead>
                                         <tr>
-                                            <td><?php echo htmlspecialchars($item['nombre_producto']); ?></td>
-                                            <td><?php echo htmlspecialchars($item['cantidad']); ?></td>
-                                            <td><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['precio_unitario'], 2)); ?></td>
-                                            <td><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['subtotal'], 2)); ?></td>
+                                            <th>Producto</th>
+                                            <th>Cantidad</th>
+                                            <th>Precio Unit.</th>
+                                            <th>Subtotal</th>
                                         </tr>
-                                        <?php endforeach; ?>
-                                    <?php endif; ?>
-                                </tbody>
-                                <tfoot>
-                                    <tr>
-                                        <th colspan="3" style="text-align: right;">Total:</th>
-                                        <th><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($venta_data['total'], 2)); ?></th>
-                                    </tr>
-                                </tfoot>
-                            </table>
+                                    </thead>
+                                    <tbody>
+                                        <?php if (!empty($venta_data['items'])): ?>
+                                            <?php foreach ($venta_data['items'] as $item): ?>
+                                            <tr>
+                                                <td><?php echo htmlspecialchars($item['nombre_producto']); ?></td>
+                                                <td><?php echo htmlspecialchars($item['cantidad']); ?></td>
+                                                <td><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['precio_unitario'], 2)); ?></td>
+                                                <td><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($item['subtotal'], 2)); ?></td>
+                                            </tr>
+                                            <?php endforeach; ?>
+                                        <?php endif; ?>
+                                    </tbody>
+                                    <tfoot>
+                                        <tr>
+                                            <th colspan="3" style="text-align: right;">Total:</th>
+                                            <th><?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($venta_data['total'], 2)); ?></th>
+                                        </tr>
+                                    </tfoot>
+                                </table>
+                            </div>
                         </div>
                     </div>
-                </div>
-
-                <div class="form-actions mt-4">
-                    <a href="ventas.php" class="btn btn-secondary">Volver a la Lista</a>
-                    <?php if (!$is_anulada): ?>
-                        <!-- Aquí se podrían agregar acciones futuras como "Imprimir" o "Enviar por Email" -->
-                        <a href="reimprimir_venta.php?id=<?php echo $venta_id; ?>" class="btn">Imprimir</a>
-                    <?php endif; ?>
-                </div>
-            </form>
+                </form>
+            </div>
+            <div class="form-actions mt-4">
+                <a href="ventas.php" class="btn btn-secondary">Volver a la Lista</a>
+                <?php if (!$is_anulada): ?>
+                    <button type="button" class="btn" onclick="window.print();">Imprimir</button>
+                <?php endif; ?>
+            </div>
         </div>
     </main>
 </div>


### PR DESCRIPTION
- Creates a new print-specific stylesheet (`print-ticket.css`) to format the sales receipt for a narrow, 80mm ticket printer.
- Modifies `venta_form.php` to use these print styles by wrapping the content and adding a print button that triggers the browser's print dialog.
- The print stylesheet hides all non-essential UI elements like the sidebar and buttons, providing a clean receipt for printing.