### PR TITLE
feat(print): Establecer tamaño de página a 80mm para impresión de tic…

### DIFF
--- a/frontend_web/assets/css/print-ticket.css
+++ b/frontend_web/assets/css/print-ticket.css
@@ -1,4 +1,19 @@
+/*
+ * CSS para impresión de tickets.
+ * Este archivo se incluye en `templates/header.php` con media="print".
+ * Se utiliza para dar formato a la vista de impresión en `venta_form.php`.
+ */
 @media print {
+    /*
+     * Define el tamaño del papel para la impresión.
+     * `80mm` es el ancho estándar para impresoras de recibos térmicos.
+     * `auto` permite que la altura se ajuste al contenido del recibo.
+     */
+    @page {
+        size: 80mm auto;
+        margin: 0;
+    }
+
     /* Ocultar todo por defecto */
     body * {
         visibility: hidden;


### PR DESCRIPTION
…kets

Se ha modificado el archivo `print-ticket.css` para incluir una regla `@page` que define explícitamente el tamaño del papel de impresión a un ancho de 80mm y una altura automática.

Esto soluciona el problema donde los navegadores por defecto usaban el tamaño A4 para la previsualización de impresión en el formulario de ventas, en lugar de un formato de ticket.

Se han añadido comentarios aclaratorios al archivo CSS para documentar la finalidad de la regla y su contexto de uso.