### PR TITLE
feat: Guardar serie y número de documento en pedidos

### DIFF
--- a/backend/api/v1/pedidos.php
+++ b/backend/api/v1/pedidos.php
@@ -31,7 +31,9 @@ switch ($request_method) {
         if (!empty($data->id_mesa) && !empty($data->id_usuario_mozo) && !empty($data->items) && is_array($data->items) && !empty($data->estado)) {
             $id_cliente = !empty($data->id_cliente) ? $data->id_cliente : null;
             $id_tipo_documento_venta = !empty($data->id_tipo_documento_venta) ? $data->id_tipo_documento_venta : null;
-            $stmt = $order->create($data->id_mesa, $data->id_usuario_mozo, $data->items, $data->estado, $id_cliente, $id_tipo_documento_venta);
+            $id_serie_documento = !empty($data->id_serie_documento) ? $data->id_serie_documento : null;
+            $numero_documento = !empty($data->numero_documento) ? $data->numero_documento : null;
+            $stmt = $order->create($data->id_mesa, $data->id_usuario_mozo, $data->items, $data->estado, $id_cliente, $id_tipo_documento_venta, $id_serie_documento, $numero_documento);
             if ($stmt) {
                 $new_order = $stmt->fetch(PDO::FETCH_ASSOC);
                 http_response_code(201);
@@ -52,7 +54,9 @@ switch ($request_method) {
         if ($order_id && !empty($data->id_mesa) && !empty($data->id_usuario_mozo) && isset($data->estado) && isset($data->items) && is_array($data->items)) {
             $id_cliente = !empty($data->id_cliente) ? $data->id_cliente : null;
             $id_tipo_documento_venta = !empty($data->id_tipo_documento_venta) ? $data->id_tipo_documento_venta : null;
-            if ($order->update($order_id, $data->id_mesa, $data->id_usuario_mozo, $data->estado, $data->items, $id_cliente, $id_tipo_documento_venta)) {
+            $id_serie_documento = !empty($data->id_serie_documento) ? $data->id_serie_documento : null;
+            $numero_documento = !empty($data->numero_documento) ? $data->numero_documento : null;
+            if ($order->update($order_id, $data->id_mesa, $data->id_usuario_mozo, $data->estado, $data->items, $id_cliente, $id_tipo_documento_venta, $id_serie_documento, $numero_documento)) {
                 http_response_code(200);
                 echo json_encode(["message" => "Pedido actualizado exitosamente."]);
             } else {

--- a/backend/database.sql
+++ b/backend/database.sql
@@ -193,6 +193,8 @@ BEGIN
         p.fecha_actualizacion,
         p.id_cliente,
         p.id_tipo_documento_venta,
+        p.id_serie_documento,
+        p.numero_documento,
         c.nombres_apellidos AS nombre_cliente,
         c.numero_documento AS ruc_cliente,
         c.id_tipo_documento_identidad AS id_tipo_documento_identidad_cliente,

--- a/backend/models/Order.php
+++ b/backend/models/Order.php
@@ -52,8 +52,8 @@ class Order {
         return $order_details;
     }
 
-    public function create($id_mesa, $id_usuario_mozo, $items, $estado = 'recibido', $id_cliente = null, $id_tipo_documento_venta = null) {
-        $query = "CALL sp_createOrder(:id_mesa, :id_usuario_mozo, :items_json, :estado, :id_cliente, :id_tipo_documento_venta)";
+    public function create($id_mesa, $id_usuario_mozo, $items, $estado = 'recibido', $id_cliente = null, $id_tipo_documento_venta = null, $id_serie_documento = null, $numero_documento = null) {
+        $query = "CALL sp_createOrder(:id_mesa, :id_usuario_mozo, :items_json, :estado, :id_cliente, :id_tipo_documento_venta, :id_serie_documento, :numero_documento)";
         $stmt = $this->conn->prepare($query);
         $items_json = json_encode($items);
         $stmt->bindParam(':id_mesa', $id_mesa);
@@ -62,14 +62,16 @@ class Order {
         $stmt->bindParam(':estado', $estado);
         $stmt->bindParam(':id_cliente', $id_cliente);
         $stmt->bindParam(':id_tipo_documento_venta', $id_tipo_documento_venta);
+        $stmt->bindParam(':id_serie_documento', $id_serie_documento);
+        $stmt->bindParam(':numero_documento', $numero_documento);
         if ($stmt->execute()) {
             return $stmt;
         }
         return false;
     }
 
-    public function update($id, $id_mesa, $id_usuario_mozo, $status, $items, $id_cliente = null, $id_tipo_documento_venta = null) {
-        $query = "CALL sp_updateOrder(:id, :id_mesa, :id_usuario_mozo, :status, :items_json, :id_cliente, :id_tipo_documento_venta)";
+    public function update($id, $id_mesa, $id_usuario_mozo, $status, $items, $id_cliente = null, $id_tipo_documento_venta = null, $id_serie_documento = null, $numero_documento = null) {
+        $query = "CALL sp_updateOrder(:id, :id_mesa, :id_usuario_mozo, :status, :items_json, :id_cliente, :id_tipo_documento_venta, :id_serie_documento, :numero_documento)";
         $stmt = $this->conn->prepare($query);
         $items_json = json_encode($items);
         $stmt->bindParam(':id', $id);
@@ -79,6 +81,8 @@ class Order {
         $stmt->bindParam(':items_json', $items_json);
         $stmt->bindParam(':id_cliente', $id_cliente);
         $stmt->bindParam(':id_tipo_documento_venta', $id_tipo_documento_venta);
+        $stmt->bindParam(':id_serie_documento', $id_serie_documento);
+        $stmt->bindParam(':numero_documento', $numero_documento);
         return $stmt->execute();
     }
 }

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -733,18 +733,23 @@ document.addEventListener('DOMContentLoaded', function() {
         ]);
 
         if (tipoComprobanteSelect.value) {
-            await loadSeries(tipoComprobanteSelect.value);
+            await loadSeries(tipoComprobanteSelect.value, isEditing ? initialOrderData.id_serie_documento : null);
         }
 
-        if (isEditing && initialOrderData && initialOrderData.id_cliente) {
-            selectCliente({
-                id: initialOrderData.id_cliente,
-                nombres_apellidos: initialOrderData.nombre_cliente,
-                id_tipo_documento_identidad: initialOrderData.id_tipo_documento_identidad_cliente,
-                numero_documento: initialOrderData.ruc_cliente,
-                direccion: initialOrderData.direccion_cliente,
-                codigo_ubigeo: initialOrderData.codigo_ubigeo
-            });
+        if (isEditing && initialOrderData) {
+            if (initialOrderData.numero_documento) {
+                document.getElementById('numero_documento').value = initialOrderData.numero_documento;
+            }
+            if (initialOrderData.id_cliente) {
+                selectCliente({
+                    id: initialOrderData.id_cliente,
+                    nombres_apellidos: initialOrderData.nombre_cliente,
+                    id_tipo_documento_identidad: initialOrderData.id_tipo_documento_identidad_cliente,
+                    numero_documento: initialOrderData.ruc_cliente,
+                    direccion: initialOrderData.direccion_cliente,
+                    codigo_ubigeo: initialOrderData.codigo_ubigeo
+                });
+            }
         } else {
             clearClienteSelection();
         }

--- a/frontend_web/pedido_handler.php
+++ b/frontend_web/pedido_handler.php
@@ -31,6 +31,8 @@ $cliente_nombre = $_POST['cliente_nombre'] ?? null;
 $cliente_direccion = $_POST['cliente_direccion'] ?? null;
 $cliente_ubigeo = $_POST['cliente_ubigeo'] ?? null;
 $id_tipo_documento_venta = $_POST['id_tipo_documento_venta'] ?? null;
+$id_serie_documento = $_POST['id_serie_documento'] ?? null;
+$numero_documento = $_POST['numero_documento'] ?? null;
 
 require_once 'config.php';
 
@@ -114,7 +116,9 @@ $api_data = [
     'estado' => $estado,
     'items' => $items,
     'id_cliente' => $id_cliente,
-    'id_tipo_documento_venta' => $id_tipo_documento_venta
+    'id_tipo_documento_venta' => $id_tipo_documento_venta,
+    'id_serie_documento' => $id_serie_documento,
+    'numero_documento' => $numero_documento
 ];
 
 // Incluir configuración de la API

--- a/update_pedidos_table.sql
+++ b/update_pedidos_table.sql
@@ -1,0 +1,10 @@
+-- Agregar las nuevas columnas a la tabla de pedidos
+ALTER TABLE pedidos
+ADD COLUMN id_serie_documento INT(11) DEFAULT NULL,
+ADD COLUMN numero_documento VARCHAR(20) DEFAULT NULL;
+
+-- Agregar la restricción de clave externa para id_serie_documento
+ALTER TABLE pedidos
+ADD CONSTRAINT fk_pedidos_serie_documento
+FOREIGN KEY (id_serie_documento) REFERENCES serie_documento(id)
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/update_stored_procedures.sql
+++ b/update_stored_procedures.sql
@@ -1,0 +1,108 @@
+DELIMITER $$
+
+CREATE OR REPLACE DEFINER = 'miguel'@'localhost'
+PROCEDURE sp_createOrder (
+    IN p_id_mesa INT,
+    IN p_id_usuario_mozo INT,
+    IN p_items_json JSON,
+    IN p_estado VARCHAR(50),
+    IN p_id_cliente INT,
+    IN p_id_tipo_documento_venta INT,
+    IN p_id_serie_documento INT,
+    IN p_numero_documento VARCHAR(20)
+)
+BEGIN
+  DECLARE v_id_pedido INT;
+  DECLARE v_total_calculado DECIMAL(10, 2) DEFAULT 0;
+  DECLARE v_item JSON;
+  DECLARE v_id_producto INT;
+  DECLARE v_cantidad INT;
+  DECLARE v_precio_unitario DECIMAL(10, 2);
+  DECLARE i INT DEFAULT 0;
+
+  START TRANSACTION;
+
+  INSERT INTO pedidos (id_mesa, id_usuario_mozo, total, estado, id_cliente, id_tipo_documento_venta, id_serie_documento, numero_documento)
+  VALUES (p_id_mesa, p_id_usuario_mozo, 0, p_estado, p_id_cliente, p_id_tipo_documento_venta, p_id_serie_documento, p_numero_documento);
+
+  SET v_id_pedido = LAST_INSERT_ID();
+
+  WHILE i < JSON_LENGTH(p_items_json) DO
+    SET v_item = JSON_EXTRACT(p_items_json, CONCAT('$[', i, ']'));
+    SET v_id_producto = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.id'));
+    SET v_cantidad = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.cantidad'));
+
+    SELECT precio INTO v_precio_unitario FROM productos WHERE id = v_id_producto;
+
+    INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario)
+    VALUES (v_id_pedido, v_id_producto, v_cantidad, v_precio_unitario);
+
+    SET v_total_calculado = v_total_calculado + (v_cantidad * v_precio_unitario);
+    SET i = i + 1;
+  END WHILE;
+
+  UPDATE pedidos SET total = v_total_calculado WHERE id = v_id_pedido;
+
+  COMMIT;
+
+  SELECT v_id_pedido AS id;
+END$$
+
+DELIMITER ;
+
+DELIMITER $$
+
+CREATE OR REPLACE DEFINER = 'miguel'@'localhost'
+PROCEDURE sp_updateOrder (
+    IN p_id_pedido INT,
+    IN p_id_mesa INT,
+    IN p_id_usuario_mozo INT,
+    IN p_estado VARCHAR(50),
+    IN p_items_json JSON,
+    IN p_id_cliente INT,
+    IN p_id_tipo_documento_venta INT,
+    IN p_id_serie_documento INT,
+    IN p_numero_documento VARCHAR(20)
+)
+BEGIN
+  DECLARE v_total_calculado DECIMAL(10, 2) DEFAULT 0;
+  DECLARE v_item JSON;
+  DECLARE v_id_producto INT;
+  DECLARE v_cantidad INT;
+  DECLARE v_precio_unitario DECIMAL(10, 2);
+  DECLARE i INT DEFAULT 0;
+
+  START TRANSACTION;
+
+  DELETE FROM detalle_pedidos WHERE id_pedido = p_id_pedido;
+
+  WHILE i < JSON_LENGTH(p_items_json) DO
+    SET v_item = JSON_EXTRACT(p_items_json, CONCAT('$[', i, ']'));
+    SET v_id_producto = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.id'));
+    SET v_cantidad = JSON_UNQUOTE(JSON_EXTRACT(v_item, '$.cantidad'));
+
+    SELECT precio INTO v_precio_unitario FROM productos WHERE id = v_id_producto;
+
+    INSERT INTO detalle_pedidos (id_pedido, id_producto, cantidad, precio_unitario)
+    VALUES (p_id_pedido, v_id_producto, v_cantidad, v_precio_unitario);
+
+    SET v_total_calculado = v_total_calculado + (v_cantidad * v_precio_unitario);
+    SET i = i + 1;
+  END WHILE;
+
+  UPDATE pedidos
+  SET id_mesa = p_id_mesa,
+      id_usuario_mozo = p_id_usuario_mozo,
+      estado = p_estado,
+      total = v_total_calculado,
+      id_cliente = p_id_cliente,
+      id_tipo_documento_venta = p_id_tipo_documento_venta,
+      id_serie_documento = p_id_serie_documento,
+      numero_documento = p_numero_documento,
+      fecha_actualizacion = CURRENT_TIMESTAMP
+  WHERE id = p_id_pedido;
+
+  COMMIT;
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
Se ha implementado la funcionalidad para guardar la serie y el número del documento de venta al crear o editar un pedido.

Cambios realizados:
- Se añadieron las columnas `id_serie_documento` y `numero_documento` a la tabla `pedidos`.
- Se actualizaron los procedimientos almacenados `sp_createOrder` y `sp_updateOrder` para manejar los nuevos campos.
- Se modificó el procedimiento `sp_getOrderDetail` para que devuelva los nuevos datos.
- Se ajustó el backend (API y modelo) para pasar los nuevos parámetros.
- Se actualizó el frontend (`pedido_handler.php` y `pedido_form.php`) para enviar los nuevos datos y mostrarlos correctamente al editar.