### PR TITLE
Fix: Corrige la validación de cliente en el formulario de pedidos

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -516,11 +516,11 @@ document.addEventListener('DOMContentLoaded', function() {
         const tipoComprobanteSelect = document.getElementById('id_tipo_documento_venta');
         const selectedComprobante = tipoComprobanteSelect.options[tipoComprobanteSelect.selectedIndex];
         if (selectedComprobante && selectedComprobante.textContent === 'Factura') {
-            const idCliente = document.getElementById('id_cliente').value;
+            const clienteRuc = document.getElementById('cliente_ruc').value;
             const clienteNombre = document.getElementById('cliente_nombre').value;
             const clienteDireccion = document.getElementById('cliente_direccion').value;
-            if (!idCliente || !clienteNombre || !clienteDireccion) {
-                alert('Para emitir una Factura, debe seleccionar un cliente con RUC, nombre y dirección.');
+            if (!clienteRuc || !clienteNombre || !clienteDireccion) {
+                alert('Para emitir una Factura, debe ingresar un RUC, nombre y dirección para el cliente.');
                 return;
             }
         } else if (document.getElementById('id_cliente').value) {


### PR DESCRIPTION
Se modifica la validación del lado del cliente en `pedido_form.php` para permitir el registro de nuevos clientes al emitir una factura.

Anteriormente, el formulario requería un ID de cliente existente, lo que impedía guardar pedidos para clientes nuevos ingresados manualmente a través de su RUC.

La nueva validación comprueba que los campos RUC, nombre y dirección estén completos, permitiendo que el backend (que ya tenía la lógica correcta) cree o actualice el cliente según corresponda.