### PR TITLE
feat: Añadir botón y lógica para calcular el cierre de caja

### DIFF
--- a/backend/api/v1/calcular_cierre.php
+++ b/backend/api/v1/calcular_cierre.php
@@ -1,0 +1,51 @@
+<?php
+header("Content-Type: application/json");
+header("Access-Control-Allow-Origin: *");
+
+require_once '../../includes/db_connect.php';
+
+$fecha = $_GET['fecha'] ?? null;
+
+if (!$fecha) {
+    http_response_code(400);
+    echo json_encode(['error' => 'La fecha es requerida.']);
+    exit;
+}
+
+try {
+    // Calcular el total de movimientos de caja para la fecha dada
+    $stmt_movimientos = $pdo->prepare("
+        SELECT
+            SUM(CASE WHEN tipo_movimiento = 'ENTRADA' THEN importe ELSE 0 END) -
+            SUM(CASE WHEN tipo_movimiento = 'SALIDA' THEN importe ELSE 0 END) as total_movimientos
+        FROM movimientos_caja
+        WHERE DATE(fecha) = :fecha
+    ");
+    $stmt_movimientos->execute(['fecha' => $fecha]);
+    $total_movimientos = $stmt_movimientos->fetchColumn();
+    if ($total_movimientos === false) {
+        $total_movimientos = 0;
+    }
+
+    // Calcular el total de ventas emitidas para la fecha dada
+    $stmt_ventas = $pdo->prepare("
+        SELECT SUM(total) as total_ventas
+        FROM ventas
+        WHERE DATE(fecha_emision) = :fecha AND estado = 'Emitida'
+    ");
+    $stmt_ventas->execute(['fecha' => $fecha]);
+    $total_ventas = $stmt_ventas->fetchColumn();
+    if ($total_ventas === false) {
+        $total_ventas = 0;
+    }
+
+    // Calcular el total de cierre
+    $total_cierre = $total_movimientos + $total_ventas;
+
+    echo json_encode(['total_cierre' => $total_cierre]);
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error en la base de datos: ' . $e->getMessage()]);
+}
+?>

--- a/frontend_web/apertura_cierre_form.php
+++ b/frontend_web/apertura_cierre_form.php
@@ -62,10 +62,13 @@ if (isset($_GET['id'])) {
 
                     <div class="form-group">
                         <label for="tipo_movimiento">Tipo de Movimiento</label>
-                        <select id="tipo_movimiento" name="tipo_movimiento" required>
-                            <option value="apertura" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'apertura') ? 'selected' : ''; ?>>Apertura</option>
-                            <option value="cierre" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'cierre') ? 'selected' : ''; ?>>Cierre</option>
-                        </select>
+                        <div style="display: flex; align-items: center;">
+                            <select id="tipo_movimiento" name="tipo_movimiento" required style="flex-grow: 1;">
+                                <option value="apertura" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'apertura') ? 'selected' : ''; ?>>Apertura</option>
+                                <option value="cierre" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'cierre') ? 'selected' : ''; ?>>Cierre</option>
+                            </select>
+                            <button type="button" id="btnCalcularCierre" class="btn" style="margin-left: 10px; display: none;">Calcular Cierre</button>
+                        </div>
                     </div>
 
                     <div class="form-group">
@@ -86,3 +89,55 @@ if (isset($_GET['id'])) {
         </div>
     </main>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const tipoMovimiento = document.getElementById('tipo_movimiento');
+    const btnCalcularCierre = document.getElementById('btnCalcularCierre');
+    const importeInput = document.getElementById('importe');
+    const fechaInput = document.getElementById('fecha');
+
+    function toggleCalcularCierreButton() {
+        if (tipoMovimiento.value === 'cierre') {
+            btnCalcularCierre.style.display = 'block';
+        } else {
+            btnCalcularCierre.style.display = 'none';
+        }
+    }
+
+    tipoMovimiento.addEventListener('change', toggleCalcularCierreButton);
+
+    btnCalcularCierre.addEventListener('click', function() {
+        const fecha = fechaInput.value;
+        if (!fecha) {
+            alert('Por favor, seleccione una fecha y hora.');
+            return;
+        }
+
+        const fechaISO = new Date(fecha).toISOString().split('T')[0];
+        const apiUrl = `<?php echo API_BASE_URL; ?>calcular_cierre.php?fecha=${fechaISO}`;
+
+        fetch(apiUrl)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('La solicitud a la API falló con el estado ' + response.status);
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data.total_cierre !== undefined) {
+                    importeInput.value = data.total_cierre;
+                } else {
+                    alert('No se pudo calcular el importe de cierre.');
+                }
+            })
+            .catch(error => {
+                console.error('Error al calcular el cierre:', error);
+                alert('Ocurrió un error al calcular el importe de cierre: ' + error.message);
+            });
+    });
+
+    // Llamada inicial para establecer el estado correcto del botón al cargar la página
+    toggleCalcularCierreButton();
+});
+</script>


### PR DESCRIPTION
- Se ha añadido un botón "Calcular Cierre" en la página `apertura_cierre_form.php`.
- Este botón solo es visible cuando el tipo de movimiento es "Cierre".
- Al hacer clic, se realiza una llamada a un nuevo endpoint de la API para calcular el importe.
- El cálculo suma las entradas, resta las salidas de caja y añade las ventas "Emitidas" para la fecha seleccionada.
- Se ha creado el endpoint `calcular_cierre.php` para manejar esta lógica de cálculo.
- El campo "Importe" se actualiza automáticamente con el resultado del cálculo.