### PR TITLE
feat: Añadir cálculo de cierre de caja con procedimiento almacenado

### DIFF
--- a/backend/api/v1/calcular_cierre.php
+++ b/backend/api/v1/calcular_cierre.php
@@ -2,7 +2,7 @@
 header("Content-Type: application/json");
 header("Access-Control-Allow-Origin: *");
 
-require_once '../../includes/db_connect.php';
+require_once __DIR__ . '/../../config/database.php';
 
 $fecha = $_GET['fecha'] ?? null;
 
@@ -13,36 +13,19 @@ if (!$fecha) {
 }
 
 try {
-    // Calcular el total de movimientos de caja para la fecha dada
-    $stmt_movimientos = $pdo->prepare("
-        SELECT
-            SUM(CASE WHEN tipo_movimiento = 'ENTRADA' THEN importe ELSE 0 END) -
-            SUM(CASE WHEN tipo_movimiento = 'SALIDA' THEN importe ELSE 0 END) as total_movimientos
-        FROM movimientos_caja
-        WHERE DATE(fecha) = :fecha
-    ");
-    $stmt_movimientos->execute(['fecha' => $fecha]);
-    $total_movimientos = $stmt_movimientos->fetchColumn();
-    if ($total_movimientos === false) {
-        $total_movimientos = 0;
-    }
+    $pdo = new PDO(DB_DSN, DB_USER, DB_PASS);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-    // Calcular el total de ventas emitidas para la fecha dada
-    $stmt_ventas = $pdo->prepare("
-        SELECT SUM(total) as total_ventas
-        FROM ventas
-        WHERE DATE(fecha_emision) = :fecha AND estado = 'Emitida'
-    ");
-    $stmt_ventas->execute(['fecha' => $fecha]);
-    $total_ventas = $stmt_ventas->fetchColumn();
-    if ($total_ventas === false) {
-        $total_ventas = 0;
-    }
+    // Llamar al procedimiento almacenado
+    $stmt = $pdo->prepare("CALL sp_calcular_cierre(:fecha)");
+    $stmt->execute(['fecha' => $fecha]);
 
-    // Calcular el total de cierre
-    $total_cierre = $total_movimientos + $total_ventas;
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
-    echo json_encode(['total_cierre' => $total_cierre]);
+    // El procedimiento almacenado devuelve una columna llamada 'total_cierre'
+    $total_cierre = $result['total_cierre'] ?? 0;
+
+    echo json_encode(['total_cierre' => (float)$total_cierre]);
 
 } catch (PDOException $e) {
     http_response_code(500);

--- a/sp_calcular_cierre.sql
+++ b/sp_calcular_cierre.sql
@@ -1,0 +1,34 @@
+DELIMITER //
+
+CREATE PROCEDURE sp_calcular_cierre(
+    IN p_fecha DATE
+)
+BEGIN
+    DECLARE total_movimientos DECIMAL(10, 2);
+    DECLARE total_ventas DECIMAL(10, 2);
+    DECLARE total_cierre DECIMAL(10, 2);
+
+    -- Calcular el total de movimientos de caja para la fecha dada
+    SELECT
+        COALESCE(SUM(CASE WHEN tipo_movimiento = 'ENTRADA' THEN importe ELSE 0 END) -
+                 SUM(CASE WHEN tipo_movimiento = 'SALIDA' THEN importe ELSE 0 END), 0)
+    INTO total_movimientos
+    FROM movimientos_caja
+    WHERE DATE(fecha) = p_fecha;
+
+    -- Calcular el total de ventas emitidas para la fecha dada
+    SELECT
+        COALESCE(SUM(total), 0)
+    INTO total_ventas
+    FROM ventas
+    WHERE DATE(fecha_emision) = p_fecha AND estado = 'Emitida';
+
+    -- Calcular el total de cierre
+    SET total_cierre = total_movimientos + total_ventas;
+
+    -- Devolver el resultado
+    SELECT total_cierre AS total_cierre;
+
+END //
+
+DELIMITER ;


### PR DESCRIPTION
- Se ha añadido un botón "Calcular Cierre" en `apertura_cierre_form.php` que se muestra solo para el tipo de movimiento "Cierre".
- Al hacer clic, se llama a un endpoint de la API que ejecuta un procedimiento almacenado para calcular el importe de cierre.
- Se ha creado el procedimiento almacenado `sp_calcular_cierre` que encapsula la lógica de negocio para el cálculo.
- El cálculo suma las entradas, resta las salidas de caja y añade las ventas "Emitidas" para la fecha seleccionada.
- El endpoint de la API (`calcular_cierre.php`) ha sido actualizado para llamar al nuevo procedimiento almacenado.
- Se ha corregido un error de conexión a la base de datos en el endpoint.