### PR TITLE
feat: Añadir cálculo de cierre y mejorar UI de tipos de movimiento

### DIFF
--- a/backend/api/v1/calcular_cierre.php
+++ b/backend/api/v1/calcular_cierre.php
@@ -1,0 +1,34 @@
+<?php
+header("Content-Type: application/json");
+header("Access-Control-Allow-Origin: *");
+
+require_once __DIR__ . '/../../config/database.php';
+
+$fecha = $_GET['fecha'] ?? null;
+
+if (!$fecha) {
+    http_response_code(400);
+    echo json_encode(['error' => 'La fecha es requerida.']);
+    exit;
+}
+
+try {
+    $pdo = new PDO(DB_DSN, DB_USER, DB_PASS);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+    // Llamar al procedimiento almacenado
+    $stmt = $pdo->prepare("CALL sp_calcular_cierre(:fecha)");
+    $stmt->execute(['fecha' => $fecha]);
+
+    $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    // El procedimiento almacenado devuelve una columna llamada 'total_cierre'
+    $total_cierre = $result['total_cierre'] ?? 0;
+
+    echo json_encode(['total_cierre' => (float)$total_cierre]);
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Error en la base de datos: ' . $e->getMessage()]);
+}
+?>

--- a/frontend_web/apertura_cierre_form.php
+++ b/frontend_web/apertura_cierre_form.php
@@ -62,10 +62,13 @@ if (isset($_GET['id'])) {
 
                     <div class="form-group">
                         <label for="tipo_movimiento">Tipo de Movimiento</label>
-                        <select id="tipo_movimiento" name="tipo_movimiento" required>
-                            <option value="apertura" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'apertura') ? 'selected' : ''; ?>>Apertura</option>
-                            <option value="cierre" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'cierre') ? 'selected' : ''; ?>>Cierre</option>
-                        </select>
+                        <div style="display: flex; align-items: center;">
+                            <select id="tipo_movimiento" name="tipo_movimiento" required style="flex-grow: 1;">
+                                <option value="apertura" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'apertura') ? 'selected' : ''; ?>>Apertura</option>
+                                <option value="cierre" <?php echo (isset($registro_data['tipo_movimiento']) && $registro_data['tipo_movimiento'] == 'cierre') ? 'selected' : ''; ?>>Cierre</option>
+                            </select>
+                            <button type="button" id="btnCalcularCierre" class="btn" style="margin-left: 10px; display: none;">Calcular Cierre</button>
+                        </div>
                     </div>
 
                     <div class="form-group">
@@ -86,3 +89,55 @@ if (isset($_GET['id'])) {
         </div>
     </main>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const tipoMovimiento = document.getElementById('tipo_movimiento');
+    const btnCalcularCierre = document.getElementById('btnCalcularCierre');
+    const importeInput = document.getElementById('importe');
+    const fechaInput = document.getElementById('fecha');
+
+    function toggleCalcularCierreButton() {
+        if (tipoMovimiento.value === 'cierre') {
+            btnCalcularCierre.style.display = 'block';
+        } else {
+            btnCalcularCierre.style.display = 'none';
+        }
+    }
+
+    tipoMovimiento.addEventListener('change', toggleCalcularCierreButton);
+
+    btnCalcularCierre.addEventListener('click', function() {
+        const fecha = fechaInput.value;
+        if (!fecha) {
+            alert('Por favor, seleccione una fecha y hora.');
+            return;
+        }
+
+        const fechaISO = new Date(fecha).toISOString().split('T')[0];
+        const apiUrl = `<?php echo API_BASE_URL; ?>calcular_cierre.php?fecha=${fechaISO}`;
+
+        fetch(apiUrl)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('La solicitud a la API falló con el estado ' + response.status);
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data.total_cierre !== undefined) {
+                    importeInput.value = data.total_cierre;
+                } else {
+                    alert('No se pudo calcular el importe de cierre.');
+                }
+            })
+            .catch(error => {
+                console.error('Error al calcular el cierre:', error);
+                alert('Ocurrió un error al calcular el importe de cierre: ' + error.message);
+            });
+    });
+
+    // Llamada inicial para establecer el estado correcto del botón al cargar la página
+    toggleCalcularCierreButton();
+});
+</script>

--- a/sp_calcular_cierre.sql
+++ b/sp_calcular_cierre.sql
@@ -1,0 +1,34 @@
+DELIMITER //
+
+CREATE PROCEDURE sp_calcular_cierre(
+    IN p_fecha DATE
+)
+BEGIN
+    DECLARE total_movimientos DECIMAL(10, 2);
+    DECLARE total_ventas DECIMAL(10, 2);
+    DECLARE total_cierre DECIMAL(10, 2);
+
+    -- Calcular el total de movimientos de caja para la fecha dada
+    SELECT
+        COALESCE(SUM(CASE WHEN tipo_movimiento = 'ENTRADA' THEN importe ELSE 0 END) -
+                 SUM(CASE WHEN tipo_movimiento = 'SALIDA' THEN importe ELSE 0 END), 0)
+    INTO total_movimientos
+    FROM movimientos_caja
+    WHERE DATE(fecha) = p_fecha;
+
+    -- Calcular el total de ventas emitidas para la fecha dada
+    SELECT
+        COALESCE(SUM(total), 0)
+    INTO total_ventas
+    FROM ventas
+    WHERE DATE(fecha_emision) = p_fecha AND estado = 'Emitida';
+
+    -- Calcular el total de cierre
+    SET total_cierre = total_movimientos + total_ventas;
+
+    -- Devolver el resultado
+    SELECT total_cierre AS total_cierre;
+
+END //
+
+DELIMITER ;


### PR DESCRIPTION
Este commit combina dos funcionalidades principales:

1.  **Cálculo de Cierre de Caja:**
    - Se añade un botón "Calcular Cierre" en `apertura_cierre_form.php`, visible solo para movimientos de "Cierre".
    - El botón llama a un endpoint de la API que ejecuta el procedimiento almacenado `sp_calcular_cierre` para obtener el importe.
    - Se crea el procedimiento almacenado `sp_calcular_cierre` para encapsular la lógica de negocio del cálculo.
    - Se crea el endpoint de la API `calcular_cierre.php` para servir como puente entre el frontend y la base de datos.

2.  **Mejora Visual en Tabla:**
    - En `apertura_cierre.php`, la columna "Tipo" ahora usa insignias de colores para una fácil distinción: verde para "Apertura" y rojo para "Cierre".