### PR TITLE
Añade validación de cierre de caja en pedidos

### DIFF
--- a/backend/api/v1/verificar_cierre.php
+++ b/backend/api/v1/verificar_cierre.php
@@ -1,0 +1,71 @@
+<?php
+// Headers para permitir el acceso a la API
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+// Incluir el archivo de conexión a la base de datos
+include_once __DIR__ . '/../../core/Database.php';
+
+// Verificar que el método de la solicitud sea GET
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+if ($request_method == 'GET') {
+    // Verificar si se proporcionó el parámetro 'fecha'
+    if (isset($_GET['fecha'])) {
+        $fecha = $_GET['fecha'];
+
+        // Validar que la fecha tenga el formato YYYY-MM-DD
+        if (preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/", $fecha)) {
+            try {
+                // Obtener instancia de la base de datos
+                $conn = Database::getInstance();
+
+                // Preparar la llamada al procedimiento almacenado
+                $query = "CALL sp_verificar_cierre_por_fecha(:fecha)";
+                $stmt = $conn->prepare($query);
+
+                // Vincular el parámetro de fecha
+                $stmt->bindParam(':fecha', $fecha, PDO::PARAM_STR);
+
+                // Ejecutar el procedimiento
+                $stmt->execute();
+
+                // Obtener el resultado
+                $result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+                // Cerrar el cursor para permitir otras consultas
+                $stmt->closeCursor();
+
+                if ($result) {
+                    // Convertir el resultado a booleano
+                    $cierre_existente = (int)$result['cierre_existente'] > 0;
+                    http_response_code(200);
+                    echo json_encode(["cierre_existente" => $cierre_existente]);
+                } else {
+                    // Error si el procedimiento no devuelve un resultado
+                    http_response_code(500);
+                    echo json_encode(["message" => "Error al verificar el cierre de caja."]);
+                }
+            } catch (PDOException $e) {
+                // Error de conexión o de consulta a la base de datos
+                http_response_code(503); // Service Unavailable
+                echo json_encode(["message" => "Error en la base de datos: " . $e->getMessage()]);
+            }
+        } else {
+            // Error si el formato de la fecha es incorrecto
+            http_response_code(400);
+            echo json_encode(["message" => "Formato de fecha inválido. Use YYYY-MM-DD."]);
+        }
+    } else {
+        // Error si no se proporciona la fecha
+        http_response_code(400);
+        echo json_encode(["message" => "El parámetro 'fecha' es requerido."]);
+    }
+} else {
+    // Error si se usa un método HTTP diferente a GET
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(["message" => "Método no permitido."]);
+}
+?>

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -476,8 +476,66 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    // --- INICIO: Funciones para validación de cierre de caja ---
+
+    /**
+     * Devuelve una fecha en formato YYYY-MM-DD.
+     * Si no se proporciona una fecha, se utiliza la fecha actual.
+     * @param {string|null} dateString - La fecha en formato ISO o similar.
+     * @returns {string} La fecha formateada.
+     */
+    function getFormattedDate(dateString = null) {
+        const date = dateString ? new Date(dateString) : new Date();
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    /**
+     * Llama a la API para verificar si existe un cierre de caja para una fecha dada.
+     * @param {string} fecha - La fecha a verificar en formato YYYY-MM-DD.
+     * @returns {Promise<boolean>} - True si existe un cierre, false en caso contrario.
+     */
+    async function verificarCierreExistente(fecha) {
+        try {
+            const response = await fetch(`${apiBaseUrl}verificar_cierre.php?fecha=${fecha}`);
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.message || 'Error de comunicación con la API de verificación.');
+            }
+            const data = await response.json();
+            return data.cierre_existente;
+        } catch (error) {
+            console.error('Error al verificar el cierre:', error);
+            // Relanzamos el error para que sea manejado por quien llama a la función.
+            throw error;
+        }
+    }
+
+    // --- FIN: Funciones para validación de cierre de caja ---
+
     orderForm.addEventListener('submit', async function(e) {
         e.preventDefault();
+
+        // --- INICIO: VALIDACIÓN DE CIERRE DE CAJA ---
+        // Determinar la fecha del pedido: la de creación si se edita, o la actual si es nuevo.
+        const fechaDelPedido = isEditing && initialOrderData.fecha_creacion
+            ? getFormattedDate(initialOrderData.fecha_creacion)
+            : getFormattedDate();
+
+        try {
+            const cierreExistente = await verificarCierreExistente(fechaDelPedido);
+            if (cierreExistente) {
+                alert('La fecha del pedido tiene un cierre de caja. No se puede crear ni modificar el pedido.');
+                return; // Detener el envío del formulario.
+            }
+        } catch (error) {
+            // Si la API falla, mostramos un error y detenemos la operación.
+            alert(`Error de Verificación: No se pudo verificar el estado de la caja: ${error.message}. Por favor, intente de nuevo.`);
+            return;
+        }
+        // --- FIN: VALIDACIÓN DE CIERRE DE CAJA ---
 
         if (isPagoView) {
             const serieSelect = document.getElementById('id_serie_documento');

--- a/sp_verificar_cierre.sql
+++ b/sp_verificar_cierre.sql
@@ -1,0 +1,18 @@
+DELIMITER $$
+
+CREATE PROCEDURE `sp_verificar_cierre_por_fecha`(
+    IN p_fecha DATE
+)
+BEGIN
+    DECLARE cierre_existente INT DEFAULT 0;
+
+    SELECT COUNT(*)
+    INTO cierre_existente
+    FROM apertura_cierre_caja
+    WHERE fecha_movimiento = p_fecha
+      AND tipo_movimiento = 'cierre';
+
+    SELECT cierre_existente AS cierre_existente;
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
Esta entrega implementa una nueva funcionalidad que impide la creación o edición de pedidos en una fecha para la cual ya existe un cierre de caja registrado.

Cambios realizados:
1.  **Nuevo Procedimiento Almacenado**: Se ha creado `sp_verificar_cierre.sql`, que contiene el procedimiento `sp_verificar_cierre_por_fecha` para comprobar si existe un cierre en una fecha específica.
2.  **Nuevo Endpoint de API**: Se ha añadido `backend/api/v1/verificar_cierre.php` para exponer la lógica de validación al frontend.
3.  **Modificación del Frontend**: Se ha actualizado el archivo `frontend_web/pedido_form.php` con lógica en JavaScript que llama al nuevo endpoint antes de enviar el formulario. Si se detecta un cierre, se muestra una alerta al usuario y se detiene la operación.

La validación utiliza la fecha actual para pedidos nuevos y la fecha de creación original (`fecha_creacion`) para pedidos en edición, según lo acordado.