### PR TITLE
Añade validación de cierre de caja en pedidos con modal

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -527,12 +527,12 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             const cierreExistente = await verificarCierreExistente(fechaDelPedido);
             if (cierreExistente) {
-                alert('La fecha del pedido tiene un cierre de caja. No se puede crear ni modificar el pedido.');
+                showAlert('Operación Bloqueada', 'La fecha del pedido tiene un cierre de caja. No se puede crear ni modificar el pedido.');
                 return; // Detener el envío del formulario.
             }
         } catch (error) {
             // Si la API falla, mostramos un error y detenemos la operación.
-            alert(`Error de Verificación: No se pudo verificar el estado de la caja: ${error.message}. Por favor, intente de nuevo.`);
+            showAlert('Error de Verificación', `No se pudo verificar el estado de la caja: ${error.message}. Por favor, intente de nuevo.`);
             return;
         }
         // --- FIN: VALIDACIÓN DE CIERRE DE CAJA ---


### PR DESCRIPTION
Esta entrega implementa una nueva funcionalidad que impide la creación o edición de pedidos en una fecha para la cual ya existe un cierre de caja registrado.

Cambios realizados:
1.  **Nuevo Procedimiento Almacenado**: Se ha creado `sp_verificar_cierre.sql`, que contiene el procedimiento `sp_verificar_cierre_por_fecha` para comprobar si existe un cierre en una fecha específica.
2.  **Nuevo Endpoint de API**: Se ha añadido `backend/api/v1/verificar_cierre.php` para exponer la lógica de validación al frontend.
3.  **Modificación del Frontend**: Se ha actualizado el archivo `frontend_web/pedido_form.php` con lógica en JavaScript que llama al nuevo endpoint antes de enviar el formulario. Si se detecta un cierre, se muestra un diálogo modal al usuario (usando la función `showAlert`) y se detiene la operación.

La validación utiliza la fecha actual para pedidos nuevos y la fecha de creación original (`fecha_creacion`) para pedidos en edición.