### PR TITLE
feat: Implementar generador de reportes dinámicos para ventas

### DIFF
--- a/backend/api/v1/reportes_ventas_handler.php
+++ b/backend/api/v1/reportes_ventas_handler.php
@@ -54,7 +54,8 @@ function get_sales_dictionary() {
 
 // --- Lógica Principal ---
 try {
-    $db = (new Database())->getConnection();
+    // Obtener la instancia de PDO usando el método estático correcto
+    $db = Database::getInstance();
     $reportesModel = new ReportesModel($db);
 } catch (Exception $e) {
     send_error('Error de conexión con la base de datos: ' . $e->getMessage(), 500);

--- a/backend/models/ReportesModel.php
+++ b/backend/models/ReportesModel.php
@@ -1,35 +1,28 @@
 <?php
 class ReportesModel {
-    private $db;
+    private $db; // Esta variable contendrá la instancia de PDO
 
-    public function __construct($db) {
-        $this->db = $db;
+    public function __construct($pdo_instance) {
+        $this->db = $pdo_instance;
     }
 
     /**
-     * Construye y ejecuta una consulta para obtener los datos del reporte dinámico.
-     * @param array $selectedColumns - Array de keys de columnas (ej. 'v.id').
-     * @param array $filters - Array de objetos de filtro.
-     * @param array $dictionary - El diccionario completo de columnas para validación y mapeo.
-     * @return array|false - Un array de resultados o false en caso de error.
+     * Construye y ejecuta una consulta para obtener los datos del reporte dinámico usando PDO.
      */
     public function getReportData($selectedColumns, $filters, $dictionary) {
-        // Mapea la key de la columna a su nombre amigable para los alias en el SELECT
         $columnMap = array_column($dictionary, 'friendly_name', 'key');
 
         $selectClause = [];
         $joinClauses = [];
-        $tables = ['v' => 'ventas']; // Siempre partimos de la tabla de ventas
+        $tables = ['v' => 'ventas'];
 
-        // Validar y construir la cláusula SELECT y los JOINS necesarios
         foreach ($selectedColumns as $colKey) {
             if (isset($columnMap[$colKey])) {
                 $selectClause[] = "{$colKey} AS `{$columnMap[$colKey]}`";
 
-                // Extraer el alias de la tabla (ej. 'c' de 'c.nombre_razon_social')
                 $tableAlias = explode('.', $colKey)[0];
                 if ($tableAlias !== 'v' && !isset($tables[$tableAlias])) {
-                    $tables[$tableAlias] = true; // Marcar la tabla como necesaria
+                    $tables[$tableAlias] = true;
                     switch ($tableAlias) {
                         case 'c':
                             $joinClauses['clientes'] = 'LEFT JOIN clientes c ON v.id_cliente = c.id';
@@ -41,7 +34,6 @@ class ReportesModel {
                             $joinClauses['tipos_documentos'] = 'LEFT JOIN tipos_documentos td ON v.id_tipo_documento = td.id';
                             break;
                         case 'mp':
-                            // Asumimos que existe una tabla metodos_pago y una columna id_metodo_pago en ventas
                             $joinClauses['metodos_pago'] = 'LEFT JOIN metodos_pago mp ON v.id_metodo_pago = mp.id';
                             break;
                     }
@@ -50,13 +42,11 @@ class ReportesModel {
         }
 
         if (empty($selectClause)) {
-            return []; // No hay columnas válidas seleccionadas
+            return [];
         }
 
-        // Construir la cláusula WHERE de forma segura
         $whereClause = "";
         $params = [];
-        $paramTypes = "";
 
         if (!empty($filters)) {
             $conditions = [];
@@ -74,9 +64,10 @@ class ReportesModel {
                         $value = '%' . $value . '%';
                     }
 
-                    $conditions[] = "{$filter['column']} {$operator} ?";
-                    $params[] = $value;
-                    $paramTypes .= 's'; // 's' para string, MySQL maneja la conversión
+                    // Usamos placeholders nombrados para mayor claridad con PDO
+                    $placeholder = ":" . str_replace('.', '_', $filter['column']) . count($params);
+                    $conditions[] = "{$filter['column']} {$operator} {$placeholder}";
+                    $params[$placeholder] = $value;
                 }
             }
 
@@ -85,101 +76,67 @@ class ReportesModel {
             }
         }
 
-        // Construir la consulta final
         $sql = "SELECT " . implode(', ', $selectClause) .
                " FROM ventas v " . implode(' ', $joinClauses) .
                " " . $whereClause . " ORDER BY v.id DESC";
 
-        // Preparar, enlazar y ejecutar la consulta
         $stmt = $this->db->prepare($sql);
-        if (!$stmt) {
-            error_log("Error al preparar la consulta: " . $this->db->error);
-            return false;
-        }
-
-        if (!empty($params)) {
-            $stmt->bind_param($paramTypes, ...$params);
-        }
-
-        $stmt->execute();
-        $result = $stmt->get_result();
-        return $result->fetch_all(MYSQLI_ASSOC);
+        $stmt->execute($params); // Pasamos el array de parámetros a execute
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
-     * Obtiene todas las plantillas de la base de datos.
-     * @return array
+     * Obtiene todas las plantillas usando PDO.
      */
     public function getTemplates() {
         $stmt = $this->db->prepare("SELECT id, nombre_plantilla FROM reporte_plantillas ORDER BY nombre_plantilla ASC");
         $stmt->execute();
-        $result = $stmt->get_result();
-        return $result->fetch_all(MYSQLI_ASSOC);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
-     * Obtiene los detalles de una plantilla específica por su ID.
-     * @param int $id
-     * @return array|null
+     * Obtiene los detalles de una plantilla específica por su ID usando PDO.
      */
     public function getTemplateById($id) {
-        $stmt = $this->db->prepare("SELECT id, nombre_plantilla, columnas FROM reporte_plantillas WHERE id = ?");
-        $stmt->bind_param('i', $id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $template = $result->fetch_assoc();
+        $stmt = $this->db->prepare("SELECT id, nombre_plantilla, columnas FROM reporte_plantillas WHERE id = :id");
+        $stmt->execute([':id' => $id]);
+        $template = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if ($template) {
-            // Decodificar el JSON de las columnas a un array de PHP
             $template['columnas'] = json_decode($template['columnas'], true);
         }
         return $template;
     }
 
     /**
-     * Guarda o actualiza una plantilla.
-     * @param string $name - Nombre de la plantilla.
-     * @param array $columnsConfig - Configuración de las columnas en formato array.
-     * @return int - El ID de la plantilla guardada o actualizada.
+     * Guarda o actualiza una plantilla usando PDO.
      */
     public function saveTemplate($name, $columnsConfig) {
-        // Verificar si ya existe una plantilla con el mismo nombre para decidir si es INSERT o UPDATE
-        $stmt_check = $this->db->prepare("SELECT id FROM reporte_plantillas WHERE nombre_plantilla = ?");
-        $stmt_check->bind_param('s', $name);
-        $stmt_check->execute();
-        $result = $stmt_check->get_result();
-        $existing = $result->fetch_assoc();
-        $stmt_check->close();
+        $stmt_check = $this->db->prepare("SELECT id FROM reporte_plantillas WHERE nombre_plantilla = :name");
+        $stmt_check->execute([':name' => $name]);
+        $existing = $stmt_check->fetch(PDO::FETCH_ASSOC);
 
         $jsonColumns = json_encode($columnsConfig);
         $newId = 0;
 
         if ($existing) {
-            // Actualizar plantilla existente
-            $stmt = $this->db->prepare("UPDATE reporte_plantillas SET columnas = ? WHERE id = ?");
-            $stmt->bind_param('si', $jsonColumns, $existing['id']);
-            $stmt->execute();
+            $stmt = $this->db->prepare("UPDATE reporte_plantillas SET columnas = :columns WHERE id = :id");
+            $stmt->execute([':columns' => $jsonColumns, ':id' => $existing['id']]);
             $newId = $existing['id'];
         } else {
-            // Insertar nueva plantilla
-            $stmt = $this->db->prepare("INSERT INTO reporte_plantillas (nombre_plantilla, columnas) VALUES (?, ?)");
-            $stmt->bind_param('ss', $name, $jsonColumns);
-            $stmt->execute();
-            $newId = $this->db->insert_id;
+            $stmt = $this->db->prepare("INSERT INTO reporte_plantillas (nombre_plantilla, columnas) VALUES (:name, :columns)");
+            $stmt->execute([':name' => $name, ':columns' => $jsonColumns]);
+            $newId = $this->db->lastInsertId();
         }
-        $stmt->close();
         return $newId;
     }
 
     /**
-     * Elimina una plantilla por su ID.
-     * @param int $id
-     * @return bool - True si se eliminó, false en caso contrario.
+     * Elimina una plantilla por su ID usando PDO.
      */
     public function deleteTemplate($id) {
-        $stmt = $this->db->prepare("DELETE FROM reporte_plantillas WHERE id = ?");
-        $stmt->bind_param('i', $id);
-        return $stmt->execute();
+        $stmt = $this->db->prepare("DELETE FROM reporte_plantillas WHERE id = :id");
+        return $stmt->execute([':id' => $id]);
     }
 }
 ?>


### PR DESCRIPTION
Se ha creado una nueva página de reportes dinámicos (`reportes_dinamicos.php`) para el módulo de ventas. Esta nueva funcionalidad replica el estilo y las características de un generador de reportes existente, permitiendo a los usuarios crear informes personalizados.

Características principales:
- Selector de columnas y filtros dinámicos.
- Gestión de plantillas (guardar, cargar, eliminar).
- Exportación de resultados a Excel.
- Backend seguro con un nuevo endpoint en la API y consultas preparadas.

fix: Se ha corregido un error fatal en el backend que impedía la carga de la configuración inicial de reportes. El problema se debía a una incompatibilidad entre MySQLi (usado en el nuevo modelo) y PDO (usado en el resto de la aplicación). Se ha reescrito el modelo para que utilice PDO y se ha corregido la instanciación de la base de datos para solucionar el problema.