### PR TITLE
feat: Implementar generador de reportes dinámicos para ventas

### DIFF
--- a/backend/api/v1/reportes_ventas_handler.php
+++ b/backend/api/v1/reportes_ventas_handler.php
@@ -1,4 +1,18 @@
 <?php
+// --- Manejador de Errores Global ---
+// Se asegura de que cualquier error no capturado devuelva una respuesta JSON válida
+// en lugar de una página de error HTML, solucionando el error "Unexpected token '<'".
+function json_exception_handler($exception) {
+    error_log("Error no capturado en reportes_ventas_handler.php: " . $exception->getMessage());
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Ocurrió un error inesperado en el servidor. Por favor, contacte a soporte.'
+    ]);
+    exit();
+}
+set_exception_handler('json_exception_handler');
+
 // Incluir la configuración de la base de datos y las funciones comunes
 // Ajustamos las rutas para que sean correctas desde __DIR__
 require_once __DIR__ . '/../../core/Database.php'; // Incluir la clase Database
@@ -33,6 +47,7 @@ function send_success($data) {
 
 // --- Diccionario de Columnas para Reportes de Ventas ---
 function get_sales_dictionary() {
+    // Diccionario corregido según el esquema de la base de datos `esquema_ventas.sql`
     return [
         ['key' => 'v.id', 'friendly_name' => 'ID Venta', 'type' => 'number'],
         ['key' => 'v.fecha_emision', 'friendly_name' => 'Fecha de Emisión', 'type' => 'date'],
@@ -40,14 +55,11 @@ function get_sales_dictionary() {
         ['key' => 'v.estado', 'friendly_name' => 'Estado Venta', 'type' => 'string'],
         ['key' => 'c.nombre_razon_social', 'friendly_name' => 'Cliente', 'type' => 'string'],
         ['key' => 'c.numero_documento', 'friendly_name' => 'Documento Cliente', 'type' => 'string'],
-        ['key' => 'u.nombre_usuario', 'friendly_name' => 'Vendedor', 'type' => 'string'],
-        ['key' => 'td.nombre', 'friendly_name' => 'Tipo Documento', 'type' => 'string'],
-        ['key' => 'v.serie', 'friendly_name' => 'Serie Documento', 'type' => 'string'],
+        ['key' => 'u.nombre_usuario', 'friendly_name' => 'Cajero', 'type' => 'string'],
+        ['key' => 'tdv.nombre', 'friendly_name' => 'Tipo Documento', 'type' => 'string'],
+        ['key' => 'sd.serie', 'friendly_name' => 'Serie Documento', 'type' => 'string'],
         ['key' => 'v.numero_documento', 'friendly_name' => 'Número Documento', 'type' => 'string'],
-        // Asumimos que existe una tabla metodos_pago, si no, comentar o eliminar la siguiente línea
-        // ['key' => 'mp.nombre', 'friendly_name' => 'Método de Pago', 'type' => 'string'],
-        ['key' => 'v.total_neto', 'friendly_name' => 'Total Neto', 'type' => 'number'],
-        ['key' => 'v.total_igv', 'friendly_name' => 'Total IGV', 'type' => 'number'],
+        // Las columnas total_neto y total_igv no existen en la tabla ventas, se eliminan.
     ];
 }
 
@@ -77,27 +89,35 @@ switch ($action) {
 
     case 'get_report':
         if ($request_method === 'POST') {
-            $json_data = file_get_contents('php://input');
-            $data = json_decode($json_data, true);
+            try {
+                $json_data = file_get_contents('php://input');
+                $data = json_decode($json_data, true);
 
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                send_error('JSON inválido.');
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    send_error('JSON inválido.');
+                }
+
+                $columns = $data['columns'] ?? [];
+                $filters = $data['filters'] ?? [];
+
+                if (empty($columns)) {
+                    send_error('Debe seleccionar al menos una columna.');
+                }
+
+                $dictionary = get_sales_dictionary();
+                $reportData = $reportesModel->getReportData($columns, $filters, $dictionary);
+
+                send_success(['data' => $reportData]);
+
+            } catch (PDOException $e) {
+                // Captura errores específicos de la base de datos (ej. SQL inválido)
+                error_log('Error de base de datos en get_report: ' . $e->getMessage());
+                send_error('Ocurrió un error al consultar la base de datos. Revise los filtros y columnas.', 500);
+            } catch (Exception $e) {
+                // Captura otros errores inesperados
+                error_log('Error inesperado en get_report: ' . $e->getMessage());
+                send_error('Ocurrió un error inesperado en el servidor.', 500);
             }
-
-            $columns = $data['columns'] ?? [];
-            $filters = $data['filters'] ?? [];
-
-            if (empty($columns)) {
-                send_error('Debe seleccionar al menos una columna.');
-            }
-
-            $dictionary = get_sales_dictionary();
-            $reportData = $reportesModel->getReportData($columns, $filters, $dictionary);
-
-            if ($reportData === false) {
-                send_error('Error al generar el reporte.', 500);
-            }
-            send_success(['data' => $reportData]);
         } else {
             send_error('Método no permitido.', 405);
         }

--- a/backend/models/ReportesModel.php
+++ b/backend/models/ReportesModel.php
@@ -8,6 +8,7 @@ class ReportesModel {
 
     /**
      * Construye y ejecuta una consulta para obtener los datos del reporte dinámico usando PDO.
+     * Corregido para coincidir con `esquema_ventas.sql`.
      */
     public function getReportData($selectedColumns, $filters, $dictionary) {
         $columnMap = array_column($dictionary, 'friendly_name', 'key');
@@ -18,6 +19,7 @@ class ReportesModel {
 
         foreach ($selectedColumns as $colKey) {
             if (isset($columnMap[$colKey])) {
+                // El alias del resultado (AS `...`) ya viene del diccionario
                 $selectClause[] = "{$colKey} AS `{$columnMap[$colKey]}`";
 
                 $tableAlias = explode('.', $colKey)[0];
@@ -28,13 +30,16 @@ class ReportesModel {
                             $joinClauses['clientes'] = 'LEFT JOIN clientes c ON v.id_cliente = c.id';
                             break;
                         case 'u':
-                            $joinClauses['usuarios'] = 'LEFT JOIN usuarios u ON v.id_usuario = u.id';
+                            // Corregido: la columna es `id_usuario_cajero`
+                            $joinClauses['usuarios'] = 'LEFT JOIN usuarios u ON v.id_usuario_cajero = u.id';
                             break;
-                        case 'td':
-                            $joinClauses['tipos_documentos'] = 'LEFT JOIN tipos_documentos td ON v.id_tipo_documento = td.id';
+                        case 'tdv':
+                            // Corregido: la tabla es `tipo_documento_venta`
+                            $joinClauses['tipo_documento_venta'] = 'LEFT JOIN tipo_documento_venta tdv ON v.id_tipo_documento_venta = tdv.id';
                             break;
-                        case 'mp':
-                            $joinClauses['metodos_pago'] = 'LEFT JOIN metodos_pago mp ON v.id_metodo_pago = mp.id';
+                        case 'sd':
+                             // Corregido: la tabla es `series_documentos`
+                            $joinClauses['series_documentos'] = 'LEFT JOIN series_documentos sd ON v.id_serie_documento = sd.id';
                             break;
                     }
                 }
@@ -64,7 +69,6 @@ class ReportesModel {
                         $value = '%' . $value . '%';
                     }
 
-                    // Usamos placeholders nombrados para mayor claridad con PDO
                     $placeholder = ":" . str_replace('.', '_', $filter['column']) . count($params);
                     $conditions[] = "{$filter['column']} {$operator} {$placeholder}";
                     $params[$placeholder] = $value;
@@ -81,7 +85,7 @@ class ReportesModel {
                " " . $whereClause . " ORDER BY v.id DESC";
 
         $stmt = $this->db->prepare($sql);
-        $stmt->execute($params); // Pasamos el array de parámetros a execute
+        $stmt->execute($params);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 


### PR DESCRIPTION
Se ha creado una nueva página de reportes dinámicos (`reportes_dinamicos.php`) para el módulo de ventas. Esta nueva funcionalidad replica el estilo y las características de un generador de reportes existente, permitiendo a los usuarios crear informes personalizados.

Características principales:
- Selector de columnas y filtros dinámicos.
- Gestión de plantillas (guardar, cargar, eliminar).
- Exportación de resultados a Excel.
- Backend seguro con un nuevo endpoint en la API y consultas preparadas.

fix: Se ha corregido la causa raíz de los errores fatales en el backend. El problema era una inconsistencia entre los nombres de tablas y columnas asumidos en el código y los definidos en el esquema real de la base de datos (`esquema_ventas.sql`).

- Se ha actualizado el diccionario de columnas y el modelo (`ReportesModel.php`) para usar los nombres de columna y las uniones de tablas correctas.
- Se ha reescrito el modelo para usar PDO, haciéndolo compatible con el núcleo de la base de datos de la aplicación.
- Se ha mejorado el manejo de errores en el backend para asegurar que siempre devuelva una respuesta JSON válida.