### PR TITLE
feat: Agregar menú de Impuestos y reordenar Clientes

### DIFF
--- a/frontend_web/impuestos.php
+++ b/frontend_web/impuestos.php
@@ -1,0 +1,26 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+$page_title = 'Gestión de Impuestos';
+include_once 'templates/header.php';
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1>Impuestos</h1>
+                <!-- El contenido de la página se desarrollará aquí más adelante -->
+            </div>
+            <div class="table-container">
+                <!-- Aquí se mostrará la tabla de impuestos en el futuro -->
+                <p>Página de impuestos en construcción.</p>
+            </div>
+        </div>
+    </main>
+</div>

--- a/frontend_web/templates/sidebar.php
+++ b/frontend_web/templates/sidebar.php
@@ -14,13 +14,14 @@
             <a href="#" class="menu-toggle"><i class="bi bi-folder-fill icon"></i> <span class="text">Maestros</span><i class="bi bi-chevron-down arrow"></i></a>
             <ul class="submenu">
                 <li><a href="empresas.php"><span class="text">Empresa</span></a></li>
+                <li><a href="clientes.php"><span class="text">Clientes</span></a></li>
                 <li><a href="productos.php"><span class="text">Productos</span></a></li>
                 <li><a href="categorias.php"><span class="text">Categorías</span></a></li>
                 <li><a href="mesas.php"><span class="text">Mesas</span></a></li>
                 <li><a href="tipos_documentos.php"><span class="text">Tipos de Documentos</span></a></li>
                 <li><a href="series_documentos.php"><span class="text">Series Documentos</span></a></li>
                 <li><a href="tipo_documento_identidad.php"><span class="text">Tipo de Documento Identidad</span></a></li>
-                <li><a href="clientes.php"><span class="text">Clientes</span></a></li>
+                <li><a href="impuestos.php"><span class="text">Impuestos</span></a></li>
             </ul>
         </li>
 


### PR DESCRIPTION
Se agrega un nuevo submenú "Impuestos" en la sección "Maestros" de la barra lateral. Se crea la página en blanco `impuestos.php` para este nuevo menú. Se mueve el submenú "Clientes" para que aparezca inmediatamente después de "Empresa".