### PR TITLE
feat: Implementar CRUD de Impuestos y reordenar menú

### DIFF
--- a/backend/api/v1/impuestos.php
+++ b/backend/api/v1/impuestos.php
@@ -1,0 +1,152 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+include_once __DIR__ . '/../../models/Impuesto.php';
+
+$impuesto = new Impuesto();
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        // Si se solicita la lista de códigos para el filtro
+        if (isset($_GET['action']) && $_GET['action'] == 'getCodigos') {
+            $stmt = $impuesto->readCodigos();
+            $num = $stmt->rowCount();
+
+            if ($num > 0) {
+                $codigos_arr = ["records" => []];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    array_push($codigos_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($codigos_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode(["records" => []]);
+            }
+        }
+        // Si se solicita un impuesto por ID
+        elseif (!empty($_GET["id"])) {
+            $impuesto_id = intval($_GET["id"]);
+            $impuesto_data = $impuesto->readOne($impuesto_id);
+
+            if ($impuesto_data) {
+                http_response_code(200);
+                echo json_encode($impuesto_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Impuesto no encontrado."]);
+            }
+        }
+        // Si se solicita la lista de impuestos con filtros y paginación
+        else {
+            // Parámetros de filtro y paginación
+            $codigo = isset($_GET['codigo']) && $_GET['codigo'] !== '' ? $_GET['codigo'] : null;
+            $estado = isset($_GET['estado']) && $_GET['estado'] !== '' ? filter_var($_GET['estado'], FILTER_VALIDATE_BOOLEAN) : null;
+            $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
+            $limit = 10;
+            $offset = ($page - 1) * $limit;
+
+            // Obtener registros y total
+            $stmt = $impuesto->readAll($codigo, $estado, $offset, $limit);
+            $total_records = $impuesto->countAll($codigo, $estado);
+
+            $num = $stmt->rowCount();
+
+            if ($num > 0) {
+                $impuestos_arr = [
+                    "records" => [],
+                    "pagination" => [
+                        "total_records" => (int)$total_records,
+                        "total_pages" => ceil($total_records / $limit),
+                        "current_page" => $page,
+                        "limit" => $limit
+                    ]
+                ];
+                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    // Convertir estado a booleano para consistencia en JSON
+                    $row['estado'] = (bool)$row['estado'];
+                    array_push($impuestos_arr["records"], $row);
+                }
+                http_response_code(200);
+                echo json_encode($impuestos_arr);
+            } else {
+                http_response_code(200);
+                echo json_encode([
+                    "records" => [],
+                    "pagination" => [
+                        "total_records" => 0,
+                        "total_pages" => 0,
+                        "current_page" => 1,
+                        "limit" => $limit
+                    ]
+                ]);
+            }
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+
+        if (!empty($data->codigo) && !empty($data->fecha_inicial) && !empty($data->fecha_final) && isset($data->valor)) {
+            $estado = isset($data->estado) ? (bool)$data->estado : true;
+
+            if ($impuesto->create($data->codigo, $data->fecha_inicial, $data->fecha_final, $data->valor, $estado)) {
+                http_response_code(201);
+                echo json_encode(["message" => "Impuesto creado con éxito."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear el impuesto."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos."]);
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        $impuesto_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+
+        if ($impuesto_id && !empty($data->codigo) && !empty($data->fecha_inicial) && !empty($data->fecha_final) && isset($data->valor)) {
+             $estado = isset($data->estado) ? (bool)$data->estado : true;
+
+            if ($impuesto->update($impuesto_id, $data->codigo, $data->fecha_inicial, $data->fecha_final, $data->valor, $estado)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Impuesto actualizado con éxito."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar el impuesto."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos para actualizar."]);
+        }
+        break;
+
+    case 'DELETE':
+        $impuesto_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+
+        if ($impuesto_id) {
+            if ($impuesto->delete($impuesto_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Impuesto eliminado con éxito."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo eliminar el impuesto."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+?>

--- a/backend/models/Impuesto.php
+++ b/backend/models/Impuesto.php
@@ -1,0 +1,110 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class Impuesto {
+    private $conn;
+
+    public function __construct() {
+        $this->conn = Database::getInstance();
+    }
+
+    /**
+     * Lee los impuestos con filtros y paginación.
+     */
+    public function readAll($codigo, $estado, $offset, $limit) {
+        $query = "CALL sp_leer_impuestos(:codigo, :estado, :offset, :limit)";
+        $stmt = $this->conn->prepare($query);
+
+        // Bind de parámetros
+        $stmt->bindParam(':codigo', $codigo, PDO::PARAM_STR);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+        $stmt->bindParam(':offset', $offset, PDO::PARAM_INT);
+        $stmt->bindParam(':limit', $limit, PDO::PARAM_INT);
+
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Cuenta el número total de impuestos con filtros.
+     */
+    public function countAll($codigo, $estado) {
+        $query = "CALL sp_contar_impuestos(:codigo, :estado, @p_total)";
+        $stmt = $this->conn->prepare($query);
+
+        $stmt->bindParam(':codigo', $codigo, PDO::PARAM_STR);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+
+        $stmt->execute();
+
+        // Recuperar el valor del parámetro de salida
+        $stmt_total = $this->conn->query("SELECT @p_total AS total");
+        $total_row = $stmt_total->fetch(PDO::FETCH_ASSOC);
+        return $total_row['total'];
+    }
+
+    /**
+     * Lee un único impuesto por su ID.
+     */
+    public function readOne($id) {
+        $query = "CALL sp_leer_impuesto_por_id(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Crea un nuevo impuesto.
+     */
+    public function create($codigo, $fecha_inicial, $fecha_final, $valor, $estado) {
+        $query = "CALL sp_crear_impuesto(:codigo, :fecha_inicial, :fecha_final, :valor, :estado)";
+        $stmt = $this->conn->prepare($query);
+
+        $stmt->bindParam(':codigo', $codigo);
+        $stmt->bindParam(':fecha_inicial', $fecha_inicial);
+        $stmt->bindParam(':fecha_final', $fecha_final);
+        $stmt->bindParam(':valor', $valor);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+
+        return $stmt->execute();
+    }
+
+    /**
+     * Actualiza un impuesto existente.
+     */
+    public function update($id, $codigo, $fecha_inicial, $fecha_final, $valor, $estado) {
+        $query = "CALL sp_actualizar_impuesto(:id, :codigo, :fecha_inicial, :fecha_final, :valor, :estado)";
+        $stmt = $this->conn->prepare($query);
+
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        $stmt->bindParam(':codigo', $codigo);
+        $stmt->bindParam(':fecha_inicial', $fecha_inicial);
+        $stmt->bindParam(':fecha_final', $fecha_final);
+        $stmt->bindParam(':valor', $valor);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+
+        return $stmt->execute();
+    }
+
+    /**
+     * Elimina un impuesto por su ID.
+     */
+    public function delete($id) {
+        $query = "CALL sp_eliminar_impuesto(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        return $stmt->execute();
+    }
+
+    /**
+     * Obtiene los códigos únicos de impuestos para los combos de filtro.
+     */
+    public function readCodigos() {
+        $query = "CALL sp_leer_codigos_impuesto()";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+}
+?>

--- a/frontend_web/impuesto_delete_handler.php
+++ b/frontend_web/impuesto_delete_handler.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if (isset($_GET['id'])) {
+    require_once 'config.php';
+    $impuesto_id = intval($_GET['id']);
+    $api_url = API_BASE_URL . 'impuestos.php?id=' . $impuesto_id;
+
+    $ch = curl_init($api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error al eliminar el impuesto.');
+
+    header("Location: impuestos.php?$message_key=$message");
+    exit();
+} else {
+    // Si no se proporciona un ID, redirigir a la lista de impuestos
+    header('Location: impuestos.php');
+    exit();
+}
+?>

--- a/frontend_web/impuesto_form.php
+++ b/frontend_web/impuesto_form.php
@@ -1,0 +1,91 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+require_once 'config.php';
+
+$page_title = 'Crear Impuesto';
+$impuesto_data = [
+    'id' => '',
+    'codigo' => '',
+    'fecha_inicial' => '',
+    'fecha_final' => '',
+    'valor' => '',
+    'estado' => 1 // Por defecto, Activo
+];
+$is_editing = false;
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $impuesto_id = intval($_GET['id']);
+    $page_title = 'Editar Impuesto';
+
+    $api_url = API_BASE_URL . "impuestos.php?id=$impuesto_id";
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $data = json_decode($response, true);
+        if ($data) {
+            $impuesto_data = $data;
+        }
+    }
+}
+
+include_once 'templates/header.php';
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+                <a href="impuestos.php" class="btn btn-secondary">Volver a la lista</a>
+            </div>
+            <div class="form-container">
+                <form id="impuesto-form" action="impuesto_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($impuesto_data['id']); ?>">
+
+                    <div class="form-group">
+                        <label for="codigo">Código</label>
+                        <input type="text" id="codigo" name="codigo" value="<?php echo htmlspecialchars($impuesto_data['codigo']); ?>" required maxlength="3">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="fecha_inicial">Fecha Inicial</label>
+                        <input type="date" id="fecha_inicial" name="fecha_inicial" value="<?php echo htmlspecialchars($impuesto_data['fecha_inicial']); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="fecha_final">Fecha Final</label>
+                        <input type="date" id="fecha_final" name="fecha_final" value="<?php echo htmlspecialchars($impuesto_data['fecha_final']); ?>" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="valor">Valor</label>
+                        <input type="number" id="valor" name="valor" value="<?php echo htmlspecialchars($impuesto_data['valor']); ?>" required step="0.01">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="estado">Estado</label>
+                        <select id="estado" name="estado">
+                            <option value="1" <?php echo ($impuesto_data['estado'] == 1) ? 'selected' : ''; ?>>Activo</option>
+                            <option value="0" <?php echo ($impuesto_data['estado'] == 0) ? 'selected' : ''; ?>>Inactivo</option>
+                        </select>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar Impuesto' : 'Grabar Impuesto'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script>
+// No se necesita JS específico para este formulario,
+// la validación se maneja con atributos HTML5 y en el backend.
+</script>

--- a/frontend_web/impuesto_handler.php
+++ b/frontend_web/impuesto_handler.php
@@ -1,0 +1,53 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once 'config.php';
+
+    $is_editing = !empty($_POST['id']);
+    $api_url = API_BASE_URL . 'impuestos.php';
+
+    $data = [
+        'codigo' => $_POST['codigo'],
+        'fecha_inicial' => $_POST['fecha_inicial'],
+        'fecha_final' => $_POST['fecha_final'],
+        'valor' => $_POST['valor'],
+        'estado' => isset($_POST['estado']) ? (bool)$_POST['estado'] : false,
+    ];
+
+    $ch = curl_init();
+    $method = 'POST';
+
+    if ($is_editing) {
+        $api_url .= '?id=' . intval($_POST['id']);
+        $method = 'PUT';
+    }
+
+    curl_setopt($ch, CURLOPT_URL, $api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error inesperado.');
+
+    header("Location: impuestos.php?$message_key=$message");
+    exit();
+} else {
+    header('Location: impuestos.php');
+    exit();
+}
+?>

--- a/frontend_web/impuestos.php
+++ b/frontend_web/impuestos.php
@@ -7,6 +7,17 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
 
 $page_title = 'Gestión de Impuestos';
 include_once 'templates/header.php';
+include_once 'config.php'; // Para API_BASE_URL
+
+// Función para obtener los códigos de impuestos para el filtro
+function getImpuestoCodigos() {
+    $api_url = API_BASE_URL . 'impuestos.php?action=getCodigos';
+    $response = file_get_contents($api_url);
+    $data = json_decode($response, true);
+    return $data['records'] ?? [];
+}
+
+$codigos_impuestos = getImpuestoCodigos();
 ?>
 
 <div class="dashboard-container">
@@ -14,13 +25,152 @@ include_once 'templates/header.php';
     <main class="main-content">
         <div class="container">
             <div class="page-header">
-                <h1>Impuestos</h1>
-                <!-- El contenido de la página se desarrollará aquí más adelante -->
+                <h1>Catálogo de Impuestos</h1>
+                <a href="impuesto_form.php" class="btn">Nuevo Impuesto</a>
             </div>
+
+            <!-- Filtros -->
+            <div class="filters-container">
+                <form id="filter-form">
+                    <div class="filter-group">
+                        <label for="codigo-filter">Código:</label>
+                        <select id="codigo-filter" name="codigo">
+                            <option value="">Todos</option>
+                            <?php foreach ($codigos_impuestos as $codigo): ?>
+                                <option value="<?php echo htmlspecialchars($codigo['codigo']); ?>">
+                                    <?php echo htmlspecialchars($codigo['codigo']); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="filter-group">
+                        <label for="estado-filter">Estado:</label>
+                        <select id="estado-filter" name="estado">
+                            <option value="">Todos</option>
+                            <option value="1">Activo</option>
+                            <option value="0">Inactivo</option>
+                        </select>
+                    </div>
+                    <div class="filter-group">
+                        <button type="submit" class="btn">Filtrar</button>
+                    </div>
+                </form>
+            </div>
+
             <div class="table-container">
-                <!-- Aquí se mostrará la tabla de impuestos en el futuro -->
-                <p>Página de impuestos en construcción.</p>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Código</th>
+                            <th>Fecha Inicial</th>
+                            <th>Fecha Final</th>
+                            <th>Valor</th>
+                            <th>Estado</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="impuestos-tbody">
+                        <!-- Los datos se cargarán aquí mediante JavaScript -->
+                    </tbody>
+                </table>
+            </div>
+            <div class="pagination-container" id="pagination-container">
+                <!-- La paginación se generará aquí -->
             </div>
         </div>
     </main>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const API_URL = '<?php echo API_BASE_URL; ?>';
+    const tbody = document.getElementById('impuestos-tbody');
+    const paginationContainer = document.getElementById('pagination-container');
+    const filterForm = document.getElementById('filter-form');
+
+    let currentPage = 1;
+
+    async function fetchImpuestos(page = 1) {
+        const formData = new FormData(filterForm);
+        const params = new URLSearchParams();
+
+        params.append('page', page);
+        if (formData.get('codigo')) {
+            params.append('codigo', formData.get('codigo'));
+        }
+        if (formData.get('estado') !== '') {
+            params.append('estado', formData.get('estado'));
+        }
+
+        try {
+            const response = await fetch(`${API_URL}impuestos.php?${params.toString()}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json();
+            renderTable(data.records);
+            renderPagination(data.pagination);
+        } catch (error) {
+            console.error('Error al obtener los impuestos:', error);
+            tbody.innerHTML = `<tr><td colspan="6">Error al cargar los datos. ${error.message}</td></tr>`;
+        }
+    }
+
+    function renderTable(impuestos) {
+        tbody.innerHTML = '';
+        if (impuestos.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6">No se encontraron impuestos.</td></tr>';
+            return;
+        }
+
+        impuestos.forEach(impuesto => {
+            const tr = document.createElement('tr');
+            const estadoText = impuesto.estado ? 'Activo' : 'Inactivo';
+            const estadoClass = impuesto.estado ? 'status-active' : 'status-inactive';
+
+            tr.innerHTML = `
+                <td>${impuesto.codigo}</td>
+                <td>${impuesto.fecha_inicial}</td>
+                <td>${impuesto.fecha_final}</td>
+                <td>${impuesto.valor}</td>
+                <td><span class="status ${estadoClass}">${estadoText}</span></td>
+                <td class="actions-cell">
+                    <a href="impuesto_form.php?id=${impuesto.id}" class="btn btn-edit">Editar</a>
+                    <a href="impuesto_delete_handler.php?id=${impuesto.id}" class="btn btn-delete" onclick="return confirm('¿Estás seguro de eliminar este impuesto?');">Eliminar</a>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    function renderPagination(pagination) {
+        paginationContainer.innerHTML = '';
+        if (pagination.total_pages <= 1) return;
+
+        for (let i = 1; i <= pagination.total_pages; i++) {
+            const pageLink = document.createElement('a');
+            pageLink.href = '#';
+            pageLink.innerText = i;
+            pageLink.classList.add('pagination-link');
+            if (i === pagination.current_page) {
+                pageLink.classList.add('active');
+            }
+            pageLink.addEventListener('click', (e) => {
+                e.preventDefault();
+                currentPage = i;
+                fetchImpuestos(currentPage);
+            });
+            paginationContainer.appendChild(pageLink);
+        }
+    }
+
+    filterForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        currentPage = 1;
+        fetchImpuestos(currentPage);
+    });
+
+    // Carga inicial
+    fetchImpuestos(currentPage);
+});
+</script>

--- a/impuestos.sql
+++ b/impuestos.sql
@@ -1,0 +1,145 @@
+-- =================================================================
+-- Archivo: impuestos.sql
+-- Descripción: Creación de la tabla de impuestos y procedimientos
+-- almacenados para el CRUD.
+-- =================================================================
+
+--
+-- 1. Creación de la tabla `impuestos`
+--
+CREATE TABLE IF NOT EXISTS `impuestos` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `codigo` CHAR(3) NOT NULL,
+  `fecha_inicial` DATE NOT NULL,
+  `fecha_final` DATE NOT NULL,
+  `valor` DECIMAL(10, 2) NOT NULL,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE, -- 1 para Activo, 0 para Inactivo
+  `fecha_creacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  `fecha_actualizacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- 2. Procedimientos Almacenados
+--
+
+-- Procedimiento para CREAR un nuevo impuesto
+DROP PROCEDURE IF EXISTS `sp_crear_impuesto`;
+DELIMITER $$
+CREATE PROCEDURE `sp_crear_impuesto`(
+    IN p_codigo CHAR(3),
+    IN p_fecha_inicial DATE,
+    IN p_fecha_final DATE,
+    IN p_valor DECIMAL(10, 2),
+    IN p_estado BOOLEAN
+)
+BEGIN
+    INSERT INTO `impuestos` (codigo, fecha_inicial, fecha_final, valor, estado)
+    VALUES (p_codigo, p_fecha_inicial, p_fecha_final, p_valor, p_estado);
+END$$
+DELIMITER ;
+
+-- Procedimiento para ACTUALIZAR un impuesto existente
+DROP PROCEDURE IF EXISTS `sp_actualizar_impuesto`;
+DELIMITER $$
+CREATE PROCEDURE `sp_actualizar_impuesto`(
+    IN p_id INT,
+    IN p_codigo CHAR(3),
+    IN p_fecha_inicial DATE,
+    IN p_fecha_final DATE,
+    IN p_valor DECIMAL(10, 2),
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE `impuestos`
+    SET
+        codigo = p_codigo,
+        fecha_inicial = p_fecha_inicial,
+        fecha_final = p_fecha_final,
+        valor = p_valor,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- Procedimiento para ELIMINAR un impuesto por su ID
+DROP PROCEDURE IF EXISTS `sp_eliminar_impuesto`;
+DELIMITER $$
+CREATE PROCEDURE `sp_eliminar_impuesto`(
+    IN p_id INT
+)
+BEGIN
+    DELETE FROM `impuestos` WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- Procedimiento para LEER impuestos con filtros y paginación
+DROP PROCEDURE IF EXISTS `sp_leer_impuestos`;
+DELIMITER $$
+CREATE PROCEDURE `sp_leer_impuestos`(
+    IN p_codigo CHAR(3),
+    IN p_estado BOOLEAN,
+    IN p_offset INT,
+    IN p_limit INT
+)
+BEGIN
+    SELECT
+        id,
+        codigo,
+        fecha_inicial,
+        fecha_final,
+        valor,
+        estado
+    FROM `impuestos`
+    WHERE
+        (p_codigo IS NULL OR codigo = p_codigo) AND
+        (p_estado IS NULL OR estado = p_estado)
+    ORDER BY id DESC
+    LIMIT p_offset, p_limit;
+END$$
+DELIMITER ;
+
+-- Procedimiento para CONTAR el total de impuestos con filtros
+DROP PROCEDURE IF EXISTS `sp_contar_impuestos`;
+DELIMITER $$
+CREATE PROCEDURE `sp_contar_impuestos`(
+    IN p_codigo CHAR(3),
+    IN p_estado BOOLEAN,
+    OUT p_total INT
+)
+BEGIN
+    SELECT COUNT(id) INTO p_total
+    FROM `impuestos`
+    WHERE
+        (p_codigo IS NULL OR codigo = p_codigo) AND
+        (p_estado IS NULL OR estado = p_estado);
+END$$
+DELIMITER ;
+
+
+-- Procedimiento para LEER un impuesto por su ID
+DROP PROCEDURE IF EXISTS `sp_leer_impuesto_por_id`;
+DELIMITER $$
+CREATE PROCEDURE `sp_leer_impuesto_por_id`(
+    IN p_id INT
+)
+BEGIN
+    SELECT
+        id,
+        codigo,
+        fecha_inicial,
+        fecha_final,
+        valor,
+        estado
+    FROM `impuestos`
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- Procedimiento para obtener los códigos únicos de impuestos para los filtros
+DROP PROCEDURE IF EXISTS `sp_leer_codigos_impuesto`;
+DELIMITER $$
+CREATE PROCEDURE `sp_leer_codigos_impuesto`()
+BEGIN
+    SELECT DISTINCT codigo FROM `impuestos` ORDER BY codigo ASC;
+END$$
+DELIMITER ;


### PR DESCRIPTION
Este commit introduce la funcionalidad completa de gestión de impuestos (CRUD) y realiza ajustes en el menú de navegación principal.

Cambios principales:
- Se añade un nuevo submenú "Impuestos" en la sección "Maestros".
- Se reordena el submenú "Clientes" para que aparezca después de "Empresa".
- Se crea la tabla `impuestos` y los procedimientos almacenados correspondientes para todas las operaciones de la base de datos (CRUD, filtros, conteo).
- Se implementa el endpoint de la API en `backend/api/v1/impuestos.php` para gestionar las solicitudes.
- Se crea el modelo `Impuesto.php` en el backend para encapsular la lógica de negocio.
- Se desarrolla la interfaz de usuario en `frontend_web/impuestos.php` con una tabla de datos, filtros, paginación y botones de acción.
- Se crea el formulario `impuesto_form.php` para añadir y editar registros.
- Se implementan los manejadores `impuesto_handler.php` y `impuesto_delete_handler.php` para procesar las acciones del frontend.