### PR TITLE
feat: Implementar CRUD de Impuestos y corregir errores

### DIFF
--- a/backend/models/Impuesto.php
+++ b/backend/models/Impuesto.php
@@ -26,10 +26,10 @@ class Impuesto {
     }
 
     /**
-     * Cuenta el número total de impuestos con filtros.
+     * Cuenta el número total de impuestos con filtros (versión corregida).
      */
     public function countAll($codigo, $estado) {
-        $query = "CALL sp_contar_impuestos(:codigo, :estado, @p_total)";
+        $query = "CALL sp_contar_impuestos(:codigo, :estado)";
         $stmt = $this->conn->prepare($query);
 
         $stmt->bindParam(':codigo', $codigo, PDO::PARAM_STR);
@@ -37,10 +37,12 @@ class Impuesto {
 
         $stmt->execute();
 
-        // Recuperar el valor del parámetro de salida
-        $stmt_total = $this->conn->query("SELECT @p_total AS total");
-        $total_row = $stmt_total->fetch(PDO::FETCH_ASSOC);
-        return $total_row['total'];
+        // Recuperar el resultado como una consulta SELECT normal
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        // Liberar el cursor para la siguiente consulta
+        $stmt->closeCursor();
+
+        return $result['total'] ?? 0;
     }
 
     /**

--- a/frontend_web/impuestos.php
+++ b/frontend_web/impuestos.php
@@ -30,9 +30,9 @@ $codigos_impuestos = getImpuestoCodigos();
             </div>
 
             <!-- Filtros -->
-            <div class="filters-container">
-                <form id="filter-form">
-                    <div class="filter-group">
+            <div class="filter-container">
+                <form id="filter-form" class="filters">
+                    <div class="form-group">
                         <label for="codigo-filter">Código:</label>
                         <select id="codigo-filter" name="codigo">
                             <option value="">Todos</option>
@@ -43,7 +43,7 @@ $codigos_impuestos = getImpuestoCodigos();
                             <?php endforeach; ?>
                         </select>
                     </div>
-                    <div class="filter-group">
+                    <div class="form-group">
                         <label for="estado-filter">Estado:</label>
                         <select id="estado-filter" name="estado">
                             <option value="">Todos</option>
@@ -51,9 +51,7 @@ $codigos_impuestos = getImpuestoCodigos();
                             <option value="0">Inactivo</option>
                         </select>
                     </div>
-                    <div class="filter-group">
-                        <button type="submit" class="btn">Filtrar</button>
-                    </div>
+                    <button type="submit" class="btn">Filtrar</button>
                 </form>
             </div>
 
@@ -64,7 +62,7 @@ $codigos_impuestos = getImpuestoCodigos();
                             <th>Código</th>
                             <th>Fecha Inicial</th>
                             <th>Fecha Final</th>
-                            <th>Valor</th>
+                            <th>Valor (%)</th>
                             <th>Estado</th>
                             <th>Acciones</th>
                         </tr>
@@ -74,7 +72,7 @@ $codigos_impuestos = getImpuestoCodigos();
                     </tbody>
                 </table>
             </div>
-            <div class="pagination-container" id="pagination-container">
+            <div class="pagination" id="pagination-container">
                 <!-- La paginación se generará aquí -->
             </div>
         </div>
@@ -129,12 +127,12 @@ document.addEventListener('DOMContentLoaded', function() {
             const estadoClass = impuesto.estado ? 'status-active' : 'status-inactive';
 
             tr.innerHTML = `
-                <td>${impuesto.codigo}</td>
-                <td>${impuesto.fecha_inicial}</td>
-                <td>${impuesto.fecha_final}</td>
-                <td>${impuesto.valor}</td>
-                <td><span class="status ${estadoClass}">${estadoText}</span></td>
-                <td class="actions-cell">
+                <td data-label="Código">${impuesto.codigo}</td>
+                <td data-label="Fecha Inicial">${impuesto.fecha_inicial}</td>
+                <td data-label="Fecha Final">${impuesto.fecha_final}</td>
+                <td data-label="Valor (%)">${impuesto.valor}</td>
+                <td data-label="Estado"><span class="status ${estadoClass}">${estadoText}</span></td>
+                <td data-label="Acciones" class="actions-cell">
                     <a href="impuesto_form.php?id=${impuesto.id}" class="btn btn-edit">Editar</a>
                     <a href="impuesto_delete_handler.php?id=${impuesto.id}" class="btn btn-delete" onclick="return confirm('¿Estás seguro de eliminar este impuesto?');">Eliminar</a>
                 </td>

--- a/impuestos.sql
+++ b/impuestos.sql
@@ -99,18 +99,18 @@ END$$
 DELIMITER ;
 
 -- Procedimiento para CONTAR el total de impuestos con filtros
+-- Procedimiento para CONTAR el total de impuestos con filtros (versión corregida)
 DROP PROCEDURE IF EXISTS `sp_contar_impuestos`;
 DELIMITER $$
 CREATE PROCEDURE `sp_contar_impuestos`(
     IN p_codigo CHAR(3),
-    IN p_estado BOOLEAN,
-    OUT p_total INT
+    IN p_estado BOOLEAN
 )
 BEGIN
-    SELECT COUNT(id) INTO p_total
+    SELECT COUNT(id) AS total
     FROM `impuestos`
     WHERE
-        (p_codigo IS NULL OR codigo = p_codigo) AND
+        (p_codigo IS NULL OR p_codigo = '' OR codigo = p_codigo) AND
         (p_estado IS NULL OR estado = p_estado);
 END$$
 DELIMITER ;


### PR DESCRIPTION
Este commit introduce la funcionalidad completa de gestión de impuestos (CRUD) y soluciona los errores iniciales de la implementación.

Cambios principales:
- Se añade un nuevo submenú "Impuestos" y se reordena "Clientes".
- Se implementa la funcionalidad CRUD completa para Impuestos (Backend y Frontend).
- Se utiliza una estructura de API, Modelo y Procedimientos Almacenados.

Correcciones:
- Se soluciona un error en el backend que causaba que la API devolviera HTML en lugar de JSON. El problema estaba en el procedimiento almacenado `sp_contar_impuestos` y su manejo en el modelo, que ahora ha sido corregido para ser más robusto.
- Se ajustan los estilos CSS en la página de `impuestos.php` para que los filtros, la tabla y la paginación sean visualmente coherentes con el resto de la aplicación.
- Se añaden atributos `data-label` a las celdas de la tabla para asegurar un diseño responsivo en dispositivos móviles.