### PR TITLE
fix: Solucionar error de JSON en el CRUD de Impuestos

### DIFF
--- a/backend/api/v1/impuestos.php
+++ b/backend/api/v1/impuestos.php
@@ -41,50 +41,38 @@ switch ($request_method) {
                 echo json_encode(["message" => "Impuesto no encontrado."]);
             }
         }
-        // Si se solicita la lista de impuestos con filtros y paginación
+        // Si se solicita la lista de impuestos con filtros y paginación (versión corregida)
         else {
             // Parámetros de filtro y paginación
             $codigo = isset($_GET['codigo']) && $_GET['codigo'] !== '' ? $_GET['codigo'] : null;
-            $estado = isset($_GET['estado']) && $_GET['estado'] !== '' ? filter_var($_GET['estado'], FILTER_VALIDATE_BOOLEAN) : null;
+            $estado_param = isset($_GET['estado']) && $_GET['estado'] !== '' ? $_GET['estado'] : null;
+            $estado = is_null($estado_param) ? null : filter_var($estado_param, FILTER_VALIDATE_BOOLEAN);
+
             $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
             $limit = 10;
             $offset = ($page - 1) * $limit;
 
-            // Obtener registros y total
-            $stmt = $impuesto->readAll($codigo, $estado, $offset, $limit);
+            // Obtener registros y total. El modelo ahora maneja el cierre de cursores.
+            $records = $impuesto->readAll($codigo, $estado, $offset, $limit);
             $total_records = $impuesto->countAll($codigo, $estado);
 
-            $num = $stmt->rowCount();
+            // Procesar registros para asegurar que el estado sea booleano
+            $processed_records = array_map(function($row) {
+                $row['estado'] = (bool)$row['estado'];
+                return $row;
+            }, $records);
 
-            if ($num > 0) {
-                $impuestos_arr = [
-                    "records" => [],
-                    "pagination" => [
-                        "total_records" => (int)$total_records,
-                        "total_pages" => ceil($total_records / $limit),
-                        "current_page" => $page,
-                        "limit" => $limit
-                    ]
-                ];
-                while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                    // Convertir estado a booleano para consistencia en JSON
-                    $row['estado'] = (bool)$row['estado'];
-                    array_push($impuestos_arr["records"], $row);
-                }
-                http_response_code(200);
-                echo json_encode($impuestos_arr);
-            } else {
-                http_response_code(200);
-                echo json_encode([
-                    "records" => [],
-                    "pagination" => [
-                        "total_records" => 0,
-                        "total_pages" => 0,
-                        "current_page" => 1,
-                        "limit" => $limit
-                    ]
-                ]);
-            }
+            $response_data = [
+                "records" => $processed_records,
+                "pagination" => [
+                    "total_records" => (int)$total_records,
+                    "total_pages" => $total_records > 0 ? ceil($total_records / $limit) : 0,
+                    "current_page" => $page,
+                    "limit" => $limit
+                ]
+            ];
+            http_response_code(200);
+            echo json_encode($response_data);
         }
         break;
 

--- a/backend/models/Impuesto.php
+++ b/backend/models/Impuesto.php
@@ -9,20 +9,27 @@ class Impuesto {
     }
 
     /**
-     * Lee los impuestos con filtros y paginación.
+     * Lee los impuestos con filtros y paginación (versión corregida).
+     * Obtiene todos los registros en un array y cierra el cursor para evitar conflictos.
      */
     public function readAll($codigo, $estado, $offset, $limit) {
         $query = "CALL sp_leer_impuestos(:codigo, :estado, :offset, :limit)";
         $stmt = $this->conn->prepare($query);
 
-        // Bind de parámetros
         $stmt->bindParam(':codigo', $codigo, PDO::PARAM_STR);
         $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
         $stmt->bindParam(':offset', $offset, PDO::PARAM_INT);
         $stmt->bindParam(':limit', $limit, PDO::PARAM_INT);
 
         $stmt->execute();
-        return $stmt;
+
+        // Obtener todos los registros en un array
+        $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        // Cerrar el cursor para permitir la siguiente consulta
+        $stmt->closeCursor();
+
+        return $records;
     }
 
     /**


### PR DESCRIPTION
Este commit resuelve el error 'Unexpected token '<'' que ocurría al cargar la página de impuestos.

La causa del error era un conflicto en la conexión a la base de datos al ejecutar dos procedimientos almacenados (`sp_leer_impuestos` y `sp_contar_impuestos`) en la misma solicitud sin gestionar adecuadamente el cursor de la base de datos.

La solución implementada consiste en:
- Modificar el método `readAll` en el modelo `Impuesto.php` para que obtenga todos los resultados en un array usando `fetchAll()` y luego cierre explícitamente el cursor con `closeCursor()`.
- Ajustar el endpoint de la API para manejar el array de resultados devuelto por el modelo.

Esto asegura que las consultas no entren en conflicto y que la API siempre devuelva una respuesta JSON válida.