### PR TITLE
fix: Hacer opcional el campo fecha_final en Impuestos

### DIFF
--- a/backend/api/v1/impuestos.php
+++ b/backend/api/v1/impuestos.php
@@ -79,10 +79,13 @@ switch ($request_method) {
     case 'POST':
         $data = json_decode(file_get_contents("php://input"));
 
-        if (!empty($data->codigo) && !empty($data->fecha_inicial) && !empty($data->fecha_final) && isset($data->valor)) {
+        // La fecha final ya no es obligatoria
+        if (!empty($data->codigo) && !empty($data->fecha_inicial) && isset($data->valor)) {
             $estado = isset($data->estado) ? (bool)$data->estado : true;
+            // Convertir fecha final vacía a NULL
+            $fecha_final = !empty($data->fecha_final) ? $data->fecha_final : null;
 
-            if ($impuesto->create($data->codigo, $data->fecha_inicial, $data->fecha_final, $data->valor, $estado)) {
+            if ($impuesto->create($data->codigo, $data->fecha_inicial, $fecha_final, $data->valor, $estado)) {
                 http_response_code(201);
                 echo json_encode(["message" => "Impuesto creado con éxito."]);
             } else {
@@ -91,7 +94,7 @@ switch ($request_method) {
             }
         } else {
             http_response_code(400);
-            echo json_encode(["message" => "Datos incompletos."]);
+            echo json_encode(["message" => "Datos incompletos. Código, fecha inicial y valor son obligatorios."]);
         }
         break;
 
@@ -99,10 +102,13 @@ switch ($request_method) {
         $data = json_decode(file_get_contents("php://input"));
         $impuesto_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
 
-        if ($impuesto_id && !empty($data->codigo) && !empty($data->fecha_inicial) && !empty($data->fecha_final) && isset($data->valor)) {
+        // La fecha final ya no es obligatoria
+        if ($impuesto_id && !empty($data->codigo) && !empty($data->fecha_inicial) && isset($data->valor)) {
              $estado = isset($data->estado) ? (bool)$data->estado : true;
+             // Convertir fecha final vacía a NULL
+             $fecha_final = !empty($data->fecha_final) ? $data->fecha_final : null;
 
-            if ($impuesto->update($impuesto_id, $data->codigo, $data->fecha_inicial, $data->fecha_final, $data->valor, $estado)) {
+            if ($impuesto->update($impuesto_id, $data->codigo, $data->fecha_inicial, $fecha_final, $data->valor, $estado)) {
                 http_response_code(200);
                 echo json_encode(["message" => "Impuesto actualizado con éxito."]);
             } else {

--- a/frontend_web/impuesto_form.php
+++ b/frontend_web/impuesto_form.php
@@ -59,8 +59,8 @@ include_once 'templates/header.php';
                     </div>
 
                     <div class="form-group">
-                        <label for="fecha_final">Fecha Final</label>
-                        <input type="date" id="fecha_final" name="fecha_final" value="<?php echo htmlspecialchars($impuesto_data['fecha_final']); ?>" required>
+                        <label for="fecha_final">Fecha Final (Opcional)</label>
+                        <input type="date" id="fecha_final" name="fecha_final" value="<?php echo htmlspecialchars($impuesto_data['fecha_final']); ?>">
                     </div>
 
                     <div class="form-group">

--- a/impuestos.sql
+++ b/impuestos.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `impuestos` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,
   `codigo` CHAR(3) NOT NULL,
   `fecha_inicial` DATE NOT NULL,
-  `fecha_final` DATE NOT NULL,
+  `fecha_final` DATE NULL, -- Modificado para ser opcional
   `valor` DECIMAL(10, 2) NOT NULL,
   `estado` BOOLEAN NOT NULL DEFAULT TRUE, -- 1 para Activo, 0 para Inactivo
   `fecha_creacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
Este commit modifica el formulario de Impuestos para que el campo 'fecha_final' ya no sea obligatorio, de acuerdo con el nuevo requerimiento.

Cambios implementados:
- Se actualizó el script `impuestos.sql` para modificar la tabla `impuestos` y permitir que la columna `fecha_final` acepte valores `NULL`.
- Se ajustó la lógica de validación en el endpoint de la API (`backend/api/v1/impuestos.php`) para que no exija la `fecha_final` y la maneje como `NULL` si está vacía.
- Se eliminó el atributo `required` del campo `fecha_final` en el formulario del frontend (`frontend_web/impuesto_form.php`).