### PR TITLE
fix: Ocultar valor nulo de fecha_final en la grilla de Impuestos

### DIFF
--- a/frontend_web/impuestos.php
+++ b/frontend_web/impuestos.php
@@ -125,11 +125,12 @@ document.addEventListener('DOMContentLoaded', function() {
             const tr = document.createElement('tr');
             const estadoText = impuesto.estado ? 'Activo' : 'Inactivo';
             const estadoClass = impuesto.estado ? 'status-active' : 'status-inactive';
+            const fechaFinalDisplay = impuesto.fecha_final || ''; // Muestra una cadena vacía si es null
 
             tr.innerHTML = `
                 <td data-label="Código">${impuesto.codigo}</td>
                 <td data-label="Fecha Inicial">${impuesto.fecha_inicial}</td>
-                <td data-label="Fecha Final">${impuesto.fecha_final}</td>
+                <td data-label="Fecha Final">${fechaFinalDisplay}</td>
                 <td data-label="Valor (%)">${impuesto.valor}</td>
                 <td data-label="Estado"><span class="status ${estadoClass}">${estadoText}</span></td>
                 <td data-label="Acciones" class="actions-cell">


### PR DESCRIPTION
Este commit realiza un ajuste visual en la página de impuestos para mejorar la presentación de los datos.

El cambio consiste en modificar la función de renderizado de la tabla en el JavaScript de `frontend_web/impuestos.php`. Se añade una comprobación para que, si el valor de `fecha_final` es nulo, se muestre una cadena de texto vacía en la celda correspondiente, en lugar de la palabra 'null'.