### PR TITLE
feat: Colores personalizados para botones de acción en ventas

### DIFF
--- a/frontend_web/assets/css/style.css
+++ b/frontend_web/assets/css/style.css
@@ -383,3 +383,36 @@ table th { background-color: var(--light-bg); font-weight: 600; }
     from { opacity: 0; }
     to { opacity: 1; }
 }
+
+/* Estilos personalizados para botones de acción en la tabla de ventas */
+.actions-cell .btn.btn-view-custom {
+    background-color: #17a2b8; /* Turquesa */
+    color: #ffffff;
+}
+.actions-cell .btn.btn-view-custom:hover {
+    background-color: #138496;
+}
+
+.actions-cell .btn.btn-edit-custom {
+    background-color: #ffc107; /* Amarillo */
+    color: #212529;
+}
+.actions-cell .btn.btn-edit-custom:hover {
+    background-color: #e0a800;
+}
+
+.actions-cell .btn.btn-annul-custom {
+    background-color: #6f42c1; /* Morado */
+    color: #ffffff;
+}
+.actions-cell .btn.btn-annul-custom:hover {
+    background-color: #5a32a3;
+}
+
+.actions-cell .btn.btn-delete-custom {
+    background-color: #dc3545; /* Rojo */
+    color: #ffffff;
+}
+.actions-cell .btn.btn-delete-custom:hover {
+    background-color: #c82333;
+}

--- a/frontend_web/ventas.php
+++ b/frontend_web/ventas.php
@@ -145,12 +145,12 @@ $pagination = $ventas_data['pagination'] ?? null;
                                         </span>
                                     </td>
                                     <td data-label="Acciones" class="actions-cell">
-                                        <a href="venta_form.php?id=<?php echo $venta['id']; ?>" class="btn btn-sm btn-success" title="Ver Venta"><i class="bi bi-eye"></i></a>
-                                        <a href="venta_edit_form.php?id=<?php echo $venta['id']; ?>" class="btn btn-sm btn-warning" title="Editar Venta"><i class="bi bi-pencil"></i></a>
+                                        <a href="venta_form.php?id=<?php echo $venta['id']; ?>" class="btn btn-sm btn-view-custom" title="Ver Venta"><i class="bi bi-eye"></i></a>
+                                        <a href="venta_edit_form.php?id=<?php echo $venta['id']; ?>" class="btn btn-sm btn-edit-custom" title="Editar Venta"><i class="bi bi-pencil"></i></a>
                                         <?php if ($venta['estado'] === 'emitida'): ?>
-                                            <button type="button" class="btn btn-sm btn-primary btn-anular" data-id="<?php echo $venta['id']; ?>" title="Anular Venta"><i class="bi bi-slash-circle"></i></button>
+                                            <button type="button" class="btn btn-sm btn-annul-custom btn-anular" data-id="<?php echo $venta['id']; ?>" title="Anular Venta"><i class="bi bi-slash-circle"></i></button>
                                         <?php endif; ?>
-                                        <button type="button" class="btn btn-sm btn-danger btn-eliminar" data-id="<?php echo $venta['id']; ?>" title="Eliminar Venta"><i class="bi bi-trash"></i></button>
+                                        <button type="button" class="btn btn-sm btn-delete-custom btn-eliminar" data-id="<?php echo $venta['id']; ?>" title="Eliminar Venta"><i class="bi bi-trash"></i></button>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>


### PR DESCRIPTION
- Se agregaron nuevas clases CSS en `style.css` para definir colores de fondo únicos para los botones de acción (Ver, Editar, Anular, Eliminar) en la página de ventas.
- Se actualizaron los botones en `ventas.php` para utilizar estas nuevas clases, reemplazando los estilos genéricos de Bootstrap.

Este cambio responde a la solicitud del usuario de diferenciar visualmente cada botón de acción en la grilla de ventas para mejorar la usabilidad.