### PR TITLE
feat: Añadir cálculo de impuestos y corregir errores de BD

### DIFF
--- a/backend/api/v1/procesar_venta.php
+++ b/backend/api/v1/procesar_venta.php
@@ -26,8 +26,8 @@ if (
 }
 
 try {
-    $database = new Database();
-    $db = $database->getConnection();
+    $db = new PDO(DB_DSN, DB_USER, DB_PASS);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
     http_response_code(503); // Service Unavailable
     echo json_encode(["message" => "No se puede conectar a la base de datos: " . $e->getMessage()]);

--- a/backend/api/v1/ventas.php
+++ b/backend/api/v1/ventas.php
@@ -13,19 +13,19 @@ include_once __DIR__ . '/../../config/database.php';
 include_once __DIR__ . '/../../models/Venta.php';
 
 try {
-    $database = new Database();
-    $db = $database->getConnection();
+    $db = new PDO(DB_DSN, DB_USER, DB_PASS);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
     http_response_code(503); // Service Unavailable
     echo json_encode(["message" => "No se puede conectar a la base de datos: " . $e->getMessage()]);
     exit();
 }
+
 $venta = new Venta($db);
 $method = $_SERVER['REQUEST_METHOD'];
 
 switch ($method) {
     case 'GET':
-        // --- Lógica de Paginación y Filtros para la lista de ventas ---
         $filtros = [
             'fecha_inicio' => $_GET['fecha_inicio'] ?? null,
             'fecha_fin' => $_GET['fecha_fin'] ?? null,

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -2,8 +2,8 @@
 // Configuración de la conexión a la base de datos
 
 define('DB_HOST', '127.0.0.1'); // O la IP de tu servidor de BD
-define('DB_USER', 'miguel');      // Usuario de la BD
-define('DB_PASS', 'Miguel123!');  // Contraseña de la BD
+define('DB_USER', 'root');      // Usuario de la BD
+define('DB_PASS', '');  // Contraseña de la BD
 define('DB_NAME', 'restaurante_db');
 
 // Opcional: configurar el DSN (Data Source Name) para PDO

--- a/backend/database/sp_read_sales.sql
+++ b/backend/database/sp_read_sales.sql
@@ -34,9 +34,9 @@ BEGIN
     WHERE
         (p_fecha_inicio IS NULL OR v.fecha_emision >= p_fecha_inicio) AND
         (p_fecha_fin IS NULL OR v.fecha_emision <= p_fecha_fin) AND
-        (p_estado IS NULL OR p_estado = 'Todos' OR v.estado = p_estado) AND
+        (p_estado IS NULL OR p_estado = 'Todos' OR v.estado COLLATE utf8mb4_unicode_ci = p_estado) AND
         (p_id_tipo_documento IS NULL OR v.id_tipo_documento_venta = p_id_tipo_documento) AND
-        (p_search IS NULL OR c.nombres_apellidos LIKE CONCAT('%', p_search, '%') OR v.numero_documento LIKE CONCAT('%', p_search, '%'))
+        (p_search IS NULL OR c.nombres_apellidos COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', p_search, '%') OR v.numero_documento COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', p_search, '%'))
     ORDER BY v.fecha_emision DESC
     LIMIT v_offset, p_limit;
 END$$
@@ -57,9 +57,9 @@ BEGIN
     WHERE
         (p_fecha_inicio IS NULL OR v.fecha_emision >= p_fecha_inicio) AND
         (p_fecha_fin IS NULL OR v.fecha_emision <= p_fecha_fin) AND
-        (p_estado IS NULL OR p_estado = 'Todos' OR v.estado = p_estado) AND
+        (p_estado IS NULL OR p_estado = 'Todos' OR v.estado COLLATE utf8mb4_unicode_ci = p_estado) AND
         (p_id_tipo_documento IS NULL OR v.id_tipo_documento_venta = p_id_tipo_documento) AND
-        (p_search IS NULL OR c.nombres_apellidos LIKE CONCAT('%', p_search, '%') OR v.numero_documento LIKE CONCAT('%', p_search, '%'));
+        (p_search IS NULL OR c.nombres_apellidos COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', p_search, '%') OR v.numero_documento COLLATE utf8mb4_unicode_ci LIKE CONCAT('%', p_search, '%'));
 END$$
 
 DELIMITER ;


### PR DESCRIPTION
Este commit implementa la funcionalidad de cálculo de impuestos en ventas y soluciona varios problemas críticos del backend.

1.  **Cálculo y Visualización de Impuestos:**
    - Se añaden las columnas `porcentaje`, `base`, e `impuesto` a la tabla `ventas`.
    - Se crean y actualizan procedimientos almacenados para manejar el cálculo y la persistencia de estos valores al crear y editar ventas.
    - El frontend (`ventas.php`) se actualiza para mostrar las nuevas columnas.

2.  **Mejora Visual de Botones:**
    - Se aplican clases CSS personalizadas a los botones de acción en `ventas.php` para darles colores únicos y mejorar la usabilidad.

3.  **Correcciones de Backend y Base de Datos:**
    - Se corrige un error de autenticación de MySQL para el usuario `root` cambiando su plugin a `mysql_native_password`.
    - Se soluciona un error de `Illegal mix of collations` en los procedimientos almacenados de lectura.
    - Se mejora el manejo de errores en los endpoints de la API (`ventas.php`, `procesar_venta.php`) para capturar excepciones de conexión a la BD y devolver un error 503.
    - Se restaura la lógica de la API para asegurar que la creación y edición de ventas funcionen correctamente con el frontend existente.