### PR TITLE
Fix: Corregir el envío de datos de pago a la API

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -548,15 +548,19 @@ document.addEventListener('DOMContentLoaded', function() {
             submitButton.disabled = true;
             submitButton.textContent = 'Procesando...';
 
-            const formData = new FormData();
-            formData.append('id_pedido', initialOrderData.id);
-            formData.append('id_serie_documento', serieSelect.value);
-            formData.append('id_tipo_documento_venta', document.getElementById('id_tipo_documento_venta').value);
+            const payload = {
+                id_pedido: initialOrderData.id,
+                id_serie_documento: serieSelect.value,
+                id_tipo_documento_venta: document.getElementById('id_tipo_documento_venta').value
+            };
 
             try {
                 const response = await fetch(`${apiBaseUrl}procesar_venta.php`, {
                     method: 'POST',
-                    body: formData
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(payload)
                 });
                 const result = await response.json();
                 if (!response.ok) throw new Error(result.message || 'Error desconocido en el servidor.');


### PR DESCRIPTION
El formulario de pago en `pedido_form.php` enviaba los datos como `FormData`, pero el endpoint de la API `procesar_venta.php` esperaba un payload JSON. Esto causaba un error de validación y el mensaje "Datos incompletos".

Esta corrección modifica el script del frontend para que construya un objeto JavaScript con los datos del pago, lo convierta a una cadena JSON y lo envíe en el cuerpo de la solicitud con la cabecera `Content-Type: application/json`.

Este cambio alinea la comunicación entre el frontend y el backend, resolviendo el problema en su origen y asegurando que los datos se procesen correctamente.