### PR TITLE
Feat: Ocultar el campo de número de documento en el formulario de pedido

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -218,7 +218,7 @@ if ($is_pago_view) {
                                             <option value="">--</option>
                                         </select>
                                     </div>
-                                    <div class="form-group" style="flex-grow: 1;">
+                                    <div class="form-group" style="flex-grow: 1; display: none;">
                                         <label for="numero_documento">Número</label>
                                         <input type="text" id="numero_documento" name="numero_documento" readonly>
                                     </div>


### PR DESCRIPTION
Este cambio oculta el campo de entrada "Número" y su etiqueta correspondiente en la página `pedido_form.php`.

El campo del número de documento ya no es necesario, ya que el correlativo se genera automáticamente en el backend al procesar la venta.

Para lograr esto, se ha añadido un estilo `display: none;` al `div` que contiene el campo y la etiqueta, eliminándolos de la vista del usuario y simplificando el formulario.