### PR TITLE
feat: Implementar CRUD de Almacenes

### DIFF
--- a/almacenes.sql
+++ b/almacenes.sql
@@ -1,0 +1,124 @@
+-- =================================================================
+-- Archivo: almacenes.sql
+-- Descripción: Creación de la tabla de almacenes y procedimientos
+-- almacenados para el CRUD.
+-- =================================================================
+
+--
+-- 1. Creación de la tabla `almacenes`
+--
+CREATE TABLE IF NOT EXISTS `almacenes` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `nombre` VARCHAR(255) NOT NULL,
+  `estado` BOOLEAN NOT NULL DEFAULT TRUE, -- 1 para Activo, 0 para Inactivo
+  `fecha_creacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  `fecha_actualizacion` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `fecha_eliminacion` DATETIME NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- 2. Procedimientos Almacenados
+--
+
+-- Procedimiento para CREAR un nuevo almacen
+DROP PROCEDURE IF EXISTS `sp_crear_almacen`;
+DELIMITER $$
+CREATE PROCEDURE `sp_crear_almacen`(
+    IN p_nombre VARCHAR(255)
+)
+BEGIN
+    INSERT INTO `almacenes` (nombre)
+    VALUES (p_nombre);
+    SELECT LAST_INSERT_ID() as id;
+END$$
+DELIMITER ;
+
+-- Procedimiento para ACTUALIZAR un almacen existente
+DROP PROCEDURE IF EXISTS `sp_actualizar_almacen`;
+DELIMITER $$
+CREATE PROCEDURE `sp_actualizar_almacen`(
+    IN p_id INT,
+    IN p_nombre VARCHAR(255),
+    IN p_estado BOOLEAN
+)
+BEGIN
+    UPDATE `almacenes`
+    SET
+        nombre = p_nombre,
+        estado = p_estado
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- Procedimiento para DESACTIVAR un almacen (eliminación lógica)
+DROP PROCEDURE IF EXISTS `sp_desactivar_almacen`;
+DELIMITER $$
+CREATE PROCEDURE `sp_desactivar_almacen`(
+    IN p_id INT
+)
+BEGIN
+    UPDATE `almacenes`
+    SET
+        estado = FALSE,
+        fecha_eliminacion = NOW()
+    WHERE id = p_id;
+END$$
+DELIMITER ;
+
+-- Procedimiento para LEER almacenes con filtros y paginación
+DROP PROCEDURE IF EXISTS `sp_leer_almacenes`;
+DELIMITER $$
+CREATE PROCEDURE `sp_leer_almacenes`(
+    IN p_nombre VARCHAR(255),
+    IN p_estado BOOLEAN,
+    IN p_offset INT,
+    IN p_limit INT
+)
+BEGIN
+    SELECT
+        id,
+        nombre,
+        estado,
+        fecha_creacion,
+        fecha_eliminacion
+    FROM `almacenes`
+    WHERE
+        (p_nombre IS NULL OR p_nombre = '' OR nombre LIKE CONCAT('%', p_nombre, '%')) AND
+        (p_estado IS NULL OR estado = p_estado)
+    ORDER BY id DESC
+    LIMIT p_offset, p_limit;
+END$$
+DELIMITER ;
+
+-- Procedimiento para CONTAR el total de almacenes con filtros
+DROP PROCEDURE IF EXISTS `sp_contar_almacenes`;
+DELIMITER $$
+CREATE PROCEDURE `sp_contar_almacenes`(
+    IN p_nombre VARCHAR(255),
+    IN p_estado BOOLEAN
+)
+BEGIN
+    SELECT COUNT(id) AS total
+    FROM `almacenes`
+    WHERE
+        (p_nombre IS NULL OR p_nombre = '' OR nombre LIKE CONCAT('%', p_nombre, '%')) AND
+        (p_estado IS NULL OR estado = p_estado);
+END$$
+DELIMITER ;
+
+
+-- Procedimiento para LEER un almacen por su ID
+DROP PROCEDURE IF EXISTS `sp_leer_almacen_por_id`;
+DELIMITER $$
+CREATE PROCEDURE `sp_leer_almacen_por_id`(
+    IN p_id INT
+)
+BEGIN
+    SELECT
+        id,
+        nombre,
+        estado
+    FROM `almacenes`
+    WHERE id = p_id;
+END$$
+DELIMITER ;

--- a/backend.log
+++ b/backend.log
@@ -1,1 +1,1 @@
-[Tue Oct  7 04:28:05 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8080) started
+[Tue Oct  7 14:40:11 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8081) started

--- a/backend/api/v1/almacenes.php
+++ b/backend/api/v1/almacenes.php
@@ -1,0 +1,127 @@
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+// Incluir el modelo de Almacen (se creará en el siguiente paso)
+include_once __DIR__ . '/../../models/Almacen.php';
+
+// Instanciar el objeto Almacen
+try {
+    $almacen = new Almacen();
+} catch (PDOException $e) {
+    http_response_code(503);
+    echo json_encode(["message" => "No se puede conectar a la base de datos."]);
+    exit();
+}
+
+$request_method = $_SERVER["REQUEST_METHOD"];
+
+switch ($request_method) {
+    case 'GET':
+        if (!empty($_GET["id"])) {
+            // Obtener un solo almacén por ID
+            $almacen_id = intval($_GET["id"]);
+            $almacen_data = $almacen->readOne($almacen_id);
+
+            if ($almacen_data) {
+                http_response_code(200);
+                echo json_encode($almacen_data);
+            } else {
+                http_response_code(404);
+                echo json_encode(["message" => "Almacén no encontrado."]);
+            }
+        } else {
+            // Obtener lista de almacenes con filtros y paginación
+            $nombre = isset($_GET['nombre']) ? $_GET['nombre'] : null;
+            $estado_param = isset($_GET['estado']) && $_GET['estado'] !== '' ? $_GET['estado'] : null;
+            $estado = is_null($estado_param) ? null : filter_var($estado_param, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+            $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
+            $limit = 10;
+            $offset = ($page - 1) * $limit;
+
+            $records = $almacen->readAll($nombre, $estado, $offset, $limit);
+            $total_records = $almacen->countAll($nombre, $estado);
+
+            $processed_records = array_map(function($row) {
+                $row['estado'] = (bool)$row['estado'];
+                return $row;
+            }, $records);
+
+            $response_data = [
+                "records" => $processed_records,
+                "pagination" => [
+                    "total_records" => (int)$total_records,
+                    "total_pages" => $total_records > 0 ? ceil($total_records / $limit) : 0,
+                    "current_page" => $page,
+                    "limit" => $limit
+                ]
+            ];
+            http_response_code(200);
+            echo json_encode($response_data);
+        }
+        break;
+
+    case 'POST':
+        $data = json_decode(file_get_contents("php://input"));
+
+        if (!empty($data->nombre)) {
+            $new_id = $almacen->create($data->nombre);
+            if ($new_id) {
+                http_response_code(201);
+                echo json_encode(["message" => "Almacén creado con éxito.", "id" => $new_id]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo crear el almacén."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos. El nombre es obligatorio."]);
+        }
+        break;
+
+    case 'PUT':
+        $data = json_decode(file_get_contents("php://input"));
+        $almacen_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+
+        if ($almacen_id && !empty($data->nombre) && isset($data->estado)) {
+            $estado = (bool)$data->estado;
+            if ($almacen->update($almacen_id, $data->nombre, $estado)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Almacén actualizado con éxito."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo actualizar el almacén."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "Datos incompletos para actualizar. Se requiere ID, nombre y estado."]);
+        }
+        break;
+
+    case 'DELETE':
+        $almacen_id = !empty($_GET['id']) ? intval($_GET['id']) : null;
+
+        if ($almacen_id) {
+            // Usamos el método de desactivación para eliminación lógica
+            if ($almacen->deactivate($almacen_id)) {
+                http_response_code(200);
+                echo json_encode(["message" => "Almacén desactivado con éxito."]);
+            } else {
+                http_response_code(503);
+                echo json_encode(["message" => "No se pudo desactivar el almacén."]);
+            }
+        } else {
+            http_response_code(400);
+            echo json_encode(["message" => "ID no proporcionado."]);
+        }
+        break;
+
+    default:
+        http_response_code(405);
+        echo json_encode(["message" => "Método no permitido."]);
+        break;
+}
+?>

--- a/backend/models/Almacen.php
+++ b/backend/models/Almacen.php
@@ -1,0 +1,103 @@
+<?php
+require_once __DIR__ . '/../core/Database.php';
+
+class Almacen {
+    private $conn;
+
+    public function __construct() {
+        try {
+            $this->conn = Database::getInstance();
+        } catch (PDOException $e) {
+            // En un caso real, podrías loguear el error o manejarlo de otra forma
+            throw new Exception("Error al conectar a la base de datos: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Lee los almacenes con filtros y paginación.
+     */
+    public function readAll($nombre, $estado, $offset, $limit) {
+        $query = "CALL sp_leer_almacenes(:nombre, :estado, :offset, :limit)";
+        $stmt = $this->conn->prepare($query);
+
+        $stmt->bindParam(':nombre', $nombre, PDO::PARAM_STR);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+        $stmt->bindParam(':offset', $offset, PDO::PARAM_INT);
+        $stmt->bindParam(':limit', $limit, PDO::PARAM_INT);
+
+        $stmt->execute();
+        $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        return $records;
+    }
+
+    /**
+     * Cuenta el número total de almacenes con filtros.
+     */
+    public function countAll($nombre, $estado) {
+        $query = "CALL sp_contar_almacenes(:nombre, :estado)";
+        $stmt = $this->conn->prepare($query);
+
+        $stmt->bindParam(':nombre', $nombre, PDO::PARAM_STR);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+
+        $stmt->execute();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+
+        return $result['total'] ?? 0;
+    }
+
+    /**
+     * Lee un único almacén por su ID.
+     */
+    public function readOne($id) {
+        $query = "CALL sp_leer_almacen_por_id(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Crea un nuevo almacén y devuelve su ID.
+     */
+    public function create($nombre) {
+        $query = "CALL sp_crear_almacen(:nombre)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':nombre', $nombre, PDO::PARAM_STR);
+
+        if ($stmt->execute()) {
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            $stmt->closeCursor();
+            return $result ? $result['id'] : false;
+        }
+        return false;
+    }
+
+    /**
+     * Actualiza un almacén existente.
+     */
+    public function update($id, $nombre, $estado) {
+        $query = "CALL sp_actualizar_almacen(:id, :nombre, :estado)";
+        $stmt = $this->conn->prepare($query);
+
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        $stmt->bindParam(':nombre', $nombre, PDO::PARAM_STR);
+        $stmt->bindParam(':estado', $estado, PDO::PARAM_BOOL);
+
+        return $stmt->execute();
+    }
+
+    /**
+     * Desactiva un almacén (eliminación lógica).
+     */
+    public function deactivate($id) {
+        $query = "CALL sp_desactivar_almacen(:id)";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+        return $stmt->execute();
+    }
+}
+?>

--- a/frontend.log
+++ b/frontend.log
@@ -1,1 +1,1 @@
-[Tue Oct  7 04:28:05 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8000) started
+[Tue Oct  7 14:40:11 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8000) started

--- a/frontend_web/almacen_form.php
+++ b/frontend_web/almacen_form.php
@@ -1,0 +1,73 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+require_once 'config.php';
+
+$page_title = 'Crear Almacén';
+$almacen_data = [
+    'id' => '',
+    'nombre' => '',
+    'estado' => 1 // Por defecto, Activo
+];
+$is_editing = false;
+
+if (isset($_GET['id'])) {
+    $is_editing = true;
+    $almacen_id = intval($_GET['id']);
+    $page_title = 'Editar Almacén';
+
+    // Llamada a la API para obtener los datos del almacén
+    $api_url = API_BASE_URL . "almacenes.php?id=$almacen_id";
+    $response = @file_get_contents($api_url);
+    if ($response) {
+        $data = json_decode($response, true);
+        if ($data) {
+            $almacen_data = $data;
+        }
+    }
+}
+
+include_once 'templates/header.php';
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1><?php echo $page_title; ?></h1>
+                <a href="almacenes.php" class="btn btn-secondary">Volver a la lista</a>
+            </div>
+            <div class="form-container">
+                <form id="almacen-form" action="almacen_handler.php" method="POST">
+                    <input type="hidden" name="id" value="<?php echo htmlspecialchars($almacen_data['id']); ?>">
+
+                    <div class="form-group">
+                        <label for="nombre">Nombre del Almacén</label>
+                        <input type="text" id="nombre" name="nombre" value="<?php echo htmlspecialchars($almacen_data['nombre']); ?>" required maxlength="255">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="estado">Estado</label>
+                        <select id="estado" name="estado">
+                            <option value="1" <?php echo (isset($almacen_data['estado']) && $almacen_data['estado'] == 1) ? 'selected' : ''; ?>>Activo</option>
+                            <option value="0" <?php echo (isset($almacen_data['estado']) && $almacen_data['estado'] == 0) ? 'selected' : ''; ?>>Inactivo</option>
+                        </select>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn"><?php echo $is_editing ? 'Actualizar Almacén' : 'Grabar Almacén'; ?></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script>
+// No se necesita JS específico para este formulario.
+</script>

--- a/frontend_web/almacen_handler.php
+++ b/frontend_web/almacen_handler.php
@@ -1,0 +1,54 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    require_once 'config.php';
+
+    $is_editing = !empty($_POST['id']);
+    $api_url = API_BASE_URL . 'almacenes.php';
+
+    // Preparar los datos para enviar a la API
+    $data = [
+        'nombre' => $_POST['nombre'],
+        'estado' => isset($_POST['estado']) ? (int)$_POST['estado'] : 0,
+    ];
+
+    $ch = curl_init();
+    $method = 'POST'; // Por defecto, para crear
+
+    if ($is_editing) {
+        $api_url .= '?id=' . intval($_POST['id']);
+        $method = 'PUT'; // Cambiar a PUT para actualizar
+    }
+
+    curl_setopt($ch, CURLOPT_URL, $api_url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'Content-Length: ' . strlen(json_encode($data))
+    ]);
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    $response_data = json_decode($response, true);
+
+    // Preparar mensaje para la redirección
+    $message_key = ($http_code >= 200 && $http_code < 300) ? 'success' : 'error';
+    $message = urlencode($response_data['message'] ?? 'Ocurrió un error inesperado.');
+
+    header("Location: almacenes.php?$message_key=$message");
+    exit();
+} else {
+    // Si no es una solicitud POST, redirigir a la lista
+    header('Location: almacenes.php');
+    exit();
+}
+?>

--- a/frontend_web/almacenes.php
+++ b/frontend_web/almacenes.php
@@ -1,0 +1,187 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header('Location: index.php');
+    exit();
+}
+
+$page_title = 'Gestión de Almacenes';
+include_once 'templates/header.php';
+include_once 'config.php'; // Para API_BASE_URL
+
+?>
+
+<div class="dashboard-container">
+    <?php include_once 'templates/sidebar.php'; ?>
+    <main class="main-content">
+        <div class="container">
+            <div class="page-header">
+                <h1>Catálogo de Almacenes</h1>
+                <a href="almacen_form.php" class="btn">Nuevo Almacén</a>
+            </div>
+
+            <!-- Filtros -->
+            <div class="filter-container">
+                <form id="filter-form" class="filters">
+                    <div class="form-group">
+                        <label for="nombre-filter">Nombre:</label>
+                        <input type="text" id="nombre-filter" name="nombre" placeholder="Buscar por nombre...">
+                    </div>
+                    <div class="form-group">
+                        <label for="estado-filter">Estado:</label>
+                        <select id="estado-filter" name="estado">
+                            <option value="">Todos</option>
+                            <option value="1">Activo</option>
+                            <option value="0">Inactivo</option>
+                        </select>
+                    </div>
+                    <button type="submit" class="btn">Filtrar</button>
+                </form>
+            </div>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Nombre</th>
+                            <th>Estado</th>
+                            <th>Fecha de Creación</th>
+                            <th>Fecha de Eliminación</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="almacenes-tbody">
+                        <!-- Los datos se cargarán aquí mediante JavaScript -->
+                    </tbody>
+                </table>
+            </div>
+            <div class="pagination" id="pagination-container">
+                <!-- La paginación se generará aquí -->
+            </div>
+        </div>
+    </main>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const API_URL = '<?php echo API_BASE_URL; ?>';
+    const tbody = document.getElementById('almacenes-tbody');
+    const paginationContainer = document.getElementById('pagination-container');
+    const filterForm = document.getElementById('filter-form');
+
+    let currentPage = 1;
+
+    async function fetchAlmacenes(page = 1) {
+        const formData = new FormData(filterForm);
+        const params = new URLSearchParams();
+
+        params.append('page', page);
+        if (formData.get('nombre')) {
+            params.append('nombre', formData.get('nombre'));
+        }
+        if (formData.get('estado') !== '') {
+            params.append('estado', formData.get('estado'));
+        }
+
+        try {
+            const response = await fetch(`${API_URL}almacenes.php?${params.toString()}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json();
+            renderTable(data.records);
+            renderPagination(data.pagination);
+        } catch (error) {
+            console.error('Error al obtener los almacenes:', error);
+            tbody.innerHTML = `<tr><td colspan="5">Error al cargar los datos. ${error.message}</td></tr>`;
+        }
+    }
+
+    function renderTable(almacenes) {
+        tbody.innerHTML = '';
+        if (almacenes.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="5">No se encontraron almacenes.</td></tr>';
+            return;
+        }
+
+        almacenes.forEach(almacen => {
+            const tr = document.createElement('tr');
+            const estadoText = almacen.estado ? 'Activo' : 'Inactivo';
+            const estadoClass = almacen.estado ? 'status-active' : 'status-inactive';
+            const fechaCreacion = new Date(almacen.fecha_creacion).toLocaleDateString();
+            const fechaEliminacion = almacen.fecha_eliminacion ? new Date(almacen.fecha_eliminacion).toLocaleDateString() : '';
+
+            tr.innerHTML = `
+                <td data-label="Nombre">${almacen.nombre}</td>
+                <td data-label="Estado"><span class="status ${estadoClass}">${estadoText}</span></td>
+                <td data-label="Fecha de Creación">${fechaCreacion}</td>
+                <td data-label="Fecha de Eliminación">${fechaEliminacion}</td>
+                <td data-label="Acciones" class="actions-cell">
+                    <a href="almacen_form.php?id=${almacen.id}" class="btn btn-edit">Editar</a>
+                    <button class="btn btn-delete" data-id="${almacen.id}">Eliminar</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    }
+
+    function renderPagination(pagination) {
+        paginationContainer.innerHTML = '';
+        if (!pagination || pagination.total_pages <= 1) return;
+
+        for (let i = 1; i <= pagination.total_pages; i++) {
+            const pageLink = document.createElement('a');
+            pageLink.href = '#';
+            pageLink.innerText = i;
+            pageLink.classList.add('pagination-link');
+            if (i === pagination.current_page) {
+                pageLink.classList.add('active');
+            }
+            pageLink.addEventListener('click', (e) => {
+                e.preventDefault();
+                currentPage = i;
+                fetchAlmacenes(currentPage);
+            });
+            paginationContainer.appendChild(pageLink);
+        }
+    }
+
+    async function deleteAlmacen(id) {
+        if (!confirm('¿Estás seguro de eliminar este almacén? Esta acción es una desactivación lógica.')) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`${API_URL}almacenes.php?id=${id}`, {
+                method: 'DELETE'
+            });
+            const result = await response.json();
+            if (response.ok) {
+                alert(result.message);
+                fetchAlmacenes(currentPage); // Recargar la tabla
+            } else {
+                throw new Error(result.message || 'Error en la respuesta del servidor');
+            }
+        } catch (error) {
+            console.error('Error al eliminar el almacén:', error);
+            alert(`No se pudo eliminar el almacén: ${error.message}`);
+        }
+    }
+
+    tbody.addEventListener('click', function(e) {
+        if (e.target && e.target.classList.contains('btn-delete')) {
+            const id = e.target.getAttribute('data-id');
+            deleteAlmacen(id);
+        }
+    });
+
+    filterForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        currentPage = 1;
+        fetchAlmacenes(currentPage);
+    });
+
+    // Carga inicial
+    fetchAlmacenes(currentPage);
+});
+</script>

--- a/frontend_web/config.php
+++ b/frontend_web/config.php
@@ -12,5 +12,5 @@ define('PUNTO_VENTA', 'Punto Venta');
 define('VENDEDOR', 'Vendedor');
 
 // Define la URL base para la API. Asegúrate de que termine con una barra inclinada (/).
-define('API_BASE_URL', 'http://localhost/personal/restaurante_system/backend/api/v1/');
+define('API_BASE_URL', 'http://localhost:8081/api/v1/');
     

--- a/frontend_web/templates/sidebar.php
+++ b/frontend_web/templates/sidebar.php
@@ -45,6 +45,7 @@
         <li class="has-submenu">
             <a href="#" class="menu-toggle"><i class="bi bi-truck icon"></i> <span class="text">Logística</span><i class="bi bi-chevron-down arrow"></i></a>
             <ul class="submenu">
+                <li><a href="almacenes.php"><span class="text">Almacenes</span></a></li>
                 <li><a href="tipo_movimiento.php"><span class="text">Tipo de Movimiento</span></a></li>
                 <li><a href="movimientos.php"><span class="text">Movimientos</span></a></li>
                 <li><a href="compras.php"><span class="text">Compras</span></a></li>                


### PR DESCRIPTION
Se añade la funcionalidad completa de Crear, Leer, Actualizar y Eliminar (CRUD) para la gestión de Almacenes en la aplicación.

Esta nueva funcionalidad incluye:
- Creación de la tabla `almacenes` y sus correspondientes procedimientos almacenados en la base de datos.
- Un nuevo endpoint en la API (`/almacenes`) para manejar las operaciones CRUD.
- Un nuevo modelo de backend (`Almacen.php`) para la lógica de negocio.
- Una nueva página en el frontend (`almacenes.php`) con una grilla para listar los almacenes, con filtros por nombre y estado.
- Un formulario (`almacen_form.php`) para la creación y edición de almacenes.
- Un manejador de formulario (`almacen_handler.php`) para procesar las solicitudes.
- Se ha añadido el enlace "Almacenes" en el menú de navegación lateral, bajo la sección "Logística".