### PR TITLE
feat(pedidos): Separa la actualización de estado de la generación de …

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -148,7 +148,7 @@ if ($is_pago_view) {
                                     }
                                 ?>
                             </button>
-                            <a href="<?php echo ($is_pago_view || $is_caja_create_view) ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
+                            <a id="volver-link" href="<?php echo ($is_pago_view || $is_caja_create_view) ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
                                 Volver a <?php echo ($is_pago_view || $is_caja_create_view) ? 'Caja' : 'Lista'; ?>
                             </a>
                         </div>
@@ -503,7 +503,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
 
                 showAlert('Éxito', 'El estado del pedido se ha actualizado correctamente.', () => {
-                    window.location.reload();
+                    const volverLink = document.getElementById('volver-link');
+                    if (volverLink) {
+                        window.location.href = volverLink.href;
+                    } else {
+                        window.location.reload(); // Fallback por si no se encuentra el enlace
+                    }
                 });
 
             } catch (error) {


### PR DESCRIPTION
…venta

Modifica el formulario de pedidos para que las acciones de estado (completar, cancelar) solo actualicen el estado del pedido a través de una llamada API específica, sin generar una venta. Tras la actualización, redirige al usuario a la página anterior.

Añade una validación en el endpoint de procesar venta para requerir una caja abierta en la fecha actual.

Crea nuevos procedimientos almacenados (sp_updateOrderStatus, sp_verificarAperturaActiva) para manejar la nueva lógica de forma aislada.

Esto resuelve el problema donde cambiar el estado de un pedido generaba incorrectamente un registro de venta.