### PR TITLE
feat(pedidos): Separa estado y venta y corrige redirección

### DIFF
--- a/frontend_web/caja.php
+++ b/frontend_web/caja.php
@@ -148,12 +148,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const statusText = (order.estado || 'desconocido').replace('_', ' ');
 
             let footerButtons = '';
-            if (order.estado === 'completado') {
-                footerButtons = `<a href="pedido_form.php?id=${order.id}&view=pago" class="btn-card btn-edit">Pagar</a>`;
+            if (order.estado === 'abierto') {
+                footerButtons = `<a href="pedido_form.php?id=${order.id}&from=caja" class="btn-card btn-edit">Ver/Editar</a>`;
+            } else if (order.estado === 'completado') {
+                footerButtons = `<a href="pedido_form.php?id=${order.id}&view=pago&from=caja" class="btn-card btn-edit">Pagar</a>`;
             } else if (order.estado === 'cancelado') {
-                footerButtons = `<a href="pedido_form.php?id=${order.id}&view=pago" class="btn-card btn-edit" style="background-color: green; color: white;">Editar</a>`;
+                // Un pedido cancelado probablemente no debería ser editable, pero mantenemos la lógica existente y añadimos el 'from'
+                footerButtons = `<a href="pedido_form.php?id=${order.id}&from=caja" class="btn-card btn-edit" style="background-color: green; color: white;">Editar</a>`;
             } else if (order.estado === 'pagado') {
-                 footerButtons = `<a href="pedido_form.php?id=${order.id}&view=pago" class="btn-card btn-view">Ver Detalle</a>`;
+                 footerButtons = `<a href="pedido_form.php?id=${order.id}&view=pago&from=caja" class="btn-card btn-view">Ver Detalle</a>`;
             }
 
             card.innerHTML = `

--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -78,6 +78,11 @@ if ($is_pago_view) {
     $form_action .= "?view=caja_create";
 }
 
+// Determinar la URL de retorno
+$from_page = $_GET['from'] ?? 'pedidos'; // 'pedidos' por defecto
+$return_url = ($from_page === 'caja' || $is_caja_create_view || $is_pago_view) ? 'caja.php' : 'pedidos.php';
+$return_page_name = ($from_page === 'caja' || $is_caja_create_view || $is_pago_view) ? 'Caja' : 'Lista';
+
 ?>
 
 <div class="dashboard-container">
@@ -148,8 +153,8 @@ if ($is_pago_view) {
                                     }
                                 ?>
                             </button>
-                            <a id="volver-link" href="<?php echo ($is_pago_view || $is_caja_create_view) ? 'caja.php' : 'pedidos.php'; ?>" class="btn btn-secondary">
-                                Volver a <?php echo ($is_pago_view || $is_caja_create_view) ? 'Caja' : 'Lista'; ?>
+                            <a id="volver-link" href="<?php echo $return_url; ?>" class="btn btn-secondary">
+                                Volver a <?php echo $return_page_name; ?>
                             </a>
                         </div>
 

--- a/frontend_web/pedidos.php
+++ b/frontend_web/pedidos.php
@@ -64,7 +64,7 @@ $orders_data = getOrders('abierto');
                                 <p class="total"><strong>Total:</strong> <?php echo CURRENCY_SYMBOL; ?><?php echo htmlspecialchars(number_format($order['total'], 2)); ?></p>
                             </div>
                             <div class="card-footer">
-                                <a href="pedido_form.php?id=<?php echo $order['id']; ?>" class="btn-card btn-edit">Editar</a>
+                                <a href="pedido_form.php?id=<?php echo $order['id']; ?>&from=pedidos" class="btn-card btn-edit">Editar</a>
                             </div>
                         </div>
                     <?php endforeach; ?>


### PR DESCRIPTION
Modifica el formulario de pedidos para que las acciones de estado solo actualicen el estado del pedido vía API, sin generar una venta.

Implementa una redirección inteligente a la página de origen (caja.php o pedidos.php) después de la actualización, usando un parámetro 'from' en la URL.

Añade una validación en el endpoint de procesar venta para requerir una caja abierta.

Crea los SPs `sp_updateOrderStatus` y `sp_verificarAperturaActiva` para la nueva lógica.

Resuelve el flujo incorrecto de actualización y asegura una navegación consistente.