### PR TITLE
feat(pedidos): Separa estado-venta y fuerza redirección

### DIFF
--- a/frontend_web/pedido_form.php
+++ b/frontend_web/pedido_form.php
@@ -507,14 +507,15 @@ document.addEventListener('DOMContentLoaded', function() {
                     throw new Error(result.message || 'Error desconocido del servidor.');
                 }
 
-                showAlert('Éxito', 'El estado del pedido se ha actualizado correctamente.', () => {
-                    const volverLink = document.getElementById('volver-link');
-                    if (volverLink) {
-                        window.location.href = volverLink.href;
-                    } else {
-                        window.location.reload(); // Fallback por si no se encuentra el enlace
-                    }
-                });
+                // Redireccionar inmediatamente después del éxito
+                const volverLink = document.getElementById('volver-link');
+                const redirectUrl = volverLink ? volverLink.href : 'pedidos.php';
+
+                // Añadimos un mensaje de éxito a la URL de redirección
+                const finalUrl = new URL(redirectUrl, window.location.origin);
+                finalUrl.searchParams.set('success', 'El estado del pedido se ha actualizado correctamente.');
+
+                window.location.href = finalUrl.href;
 
             } catch (error) {
                 console.error('Error al actualizar el estado:', error);


### PR DESCRIPTION
Modifica el formulario de pedidos para que las acciones de estado solo actualicen el estado del pedido vía API, sin generar una venta.

Implementa una redirección forzada e inmediata a la página de origen (caja.php o pedidos.php) tras la actualización para garantizar una navegación fiable.

Añade una validación en el endpoint de procesar venta para requerir una caja abierta.

Crea los SPs `sp_updateOrderStatus` y `sp_verificarAperturaActiva` para la nueva lógica.

Resuelve el flujo incorrecto de actualización y asegura una navegación consistente.