### PR TITLE
feat(pedidos): Previene ventas duplicadas y mejora flujo

### DIFF
--- a/backend/api/v1/procesar_venta.php
+++ b/backend/api/v1/procesar_venta.php
@@ -46,6 +46,13 @@ if (empty($id_usuario_cajero)) {
 }
 
 try {
+    // Primero, verificar si ya existe una venta para este pedido
+    if ($venta->ventaExistePorPedido($data->id_pedido)) {
+        http_response_code(409); // Conflict
+        echo json_encode(["message" => "Este pedido ya tiene una venta generada. No se puede procesar nuevamente."]);
+        exit;
+    }
+
     // Validación de apertura de caja
     $fecha_actual = date('Y-m-d');
     if (!$apertura_cierre->verificarAperturaActiva($fecha_actual)) {

--- a/backend/models/Venta.php
+++ b/backend/models/Venta.php
@@ -145,5 +145,15 @@ class Venta {
             return null;
         }
     }
+
+    public function ventaExistePorPedido($id_pedido) {
+        $query = "CALL sp_verificarVentaPorPedido(:id_pedido)";
+        $stmt = $this->pdo->prepare($query);
+        $stmt->bindParam(':id_pedido', $id_pedido, PDO::PARAM_INT);
+        $stmt->execute();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+        return ($result['venta_existente'] > 0);
+    }
 }
 ?>

--- a/database/feature_pedido_updates.sql
+++ b/database/feature_pedido_updates.sql
@@ -24,6 +24,19 @@ BEGIN
 END //
 DELIMITER ;
 
+-- 3. Procedimiento para verificar si un pedido ya tiene una venta generada.
+DROP PROCEDURE IF EXISTS sp_verificarVentaPorPedido;
+DELIMITER //
+CREATE PROCEDURE sp_verificarVentaPorPedido(
+    IN p_id_pedido INT
+)
+BEGIN
+    SELECT COUNT(id) AS venta_existente
+    FROM ventas
+    WHERE id_pedido = p_id_pedido;
+END //
+DELIMITER ;
+
 
 -- 2. Procedimiento para verificar si hay una caja abierta para una fecha específica.
 -- Este SP es crucial para el endpoint de "procesar_venta.php".


### PR DESCRIPTION
Añade una validación en `procesar_venta.php` para impedir que se genere más de una venta por pedido, utilizando el nuevo SP `sp_verificarVentaPorPedido`.

Refactoriza el formulario de pedidos para que las acciones de estado solo actualicen el estado vía API y redirijan correctamente a la página anterior.

Asegura que solo se puedan procesar ventas si hay una caja abierta en la fecha actual.

Este conjunto de cambios robustece el proceso de venta, previene la duplicación de datos y mejora la experiencia de usuario.