### PR TITLE
feat(ventas): Añade columna de Pedido a la grilla

### DIFF
--- a/database/hotfix_add_pedido_id_to_ventas.sql
+++ b/database/hotfix_add_pedido_id_to_ventas.sql
@@ -1,0 +1,45 @@
+-- Hotfix para añadir id_pedido al listado de ventas.
+
+DROP PROCEDURE IF EXISTS sp_leer_ventas;
+DELIMITER //
+CREATE PROCEDURE sp_leer_ventas(
+    IN p_fecha_inicio DATE,
+    IN p_fecha_fin DATE,
+    IN p_estado VARCHAR(20),
+    IN p_id_tipo_documento INT,
+    IN p_search VARCHAR(100),
+    IN p_page INT,
+    IN p_limit INT
+)
+BEGIN
+    DECLARE v_offset INT;
+    SET v_offset = (p_page - 1) * p_limit;
+
+    SELECT
+        v.id,
+        v.id_pedido, -- <--- Columna añadida
+        v.fecha_emision,
+        c.nombres_apellidos AS nombre_cliente,
+        tdv.descripcion,
+        sd.serie,
+        v.numero_documento,
+        i.porcentaje,
+        v.base,
+        v.impuesto,
+        v.total,
+        v.estado
+    FROM ventas v
+    LEFT JOIN clientes c ON v.id_cliente = c.id
+    LEFT JOIN tipos_documentos_venta tdv ON v.id_tipo_documento_venta = tdv.id
+    LEFT JOIN series_documentos sd ON v.id_serie_documento = sd.id
+    LEFT JOIN impuestos i ON tdv.id_impuesto = i.id
+    WHERE
+        (p_fecha_inicio IS NULL OR v.fecha_emision >= p_fecha_inicio) AND
+        (p_fecha_fin IS NULL OR v.fecha_emision <= p_fecha_fin) AND
+        (p_estado = 'Todos' OR v.estado = p_estado) AND
+        (p_id_tipo_documento IS NULL OR v.id_tipo_documento_venta = p_id_tipo_documento) AND
+        (p_search IS NULL OR c.nombres_apellidos LIKE CONCAT('%', p_search, '%') OR v.numero_documento LIKE CONCAT('%', p_search, '%'))
+    ORDER BY v.fecha_emision DESC, v.id DESC
+    LIMIT v_offset, p_limit;
+END //
+DELIMITER ;

--- a/frontend_web/ventas.php
+++ b/frontend_web/ventas.php
@@ -123,6 +123,7 @@ $pagination = $ventas_data['pagination'] ?? null;
                     <thead>
                         <tr>
                             <th>ID</th>
+                            <th>Pedido</th>
                             <th>Fecha Emisión</th>
                             <th>Cliente</th>
                             <th>Documento</th>
@@ -139,6 +140,7 @@ $pagination = $ventas_data['pagination'] ?? null;
                             <?php foreach ($ventas as $venta): ?>
                                 <tr>
                                     <td data-label="ID"><?php echo htmlspecialchars($venta['id']); ?></td>
+                                    <td data-label="Pedido"><?php echo htmlspecialchars($venta['id_pedido'] ?? 'N/A'); ?></td>
                                     <td data-label="Fecha Emisión"><?php echo htmlspecialchars(date("d/m/Y", strtotime($venta['fecha_emision']))); ?></td>
                                     <td data-label="Cliente"><?php echo htmlspecialchars($venta['nombre_cliente'] ?? 'Varios'); ?></td>
                                     <td data-label="Documento"><?php echo htmlspecialchars($venta['descripcion'] . ' ' . $venta['serie'] . '-' . $venta['numero_documento']); ?></td>


### PR DESCRIPTION
Modifica el procedimiento almacenado `sp_leer_ventas` para que devuelva el `id_pedido` asociado a cada venta.

Actualiza la tabla en la página `ventas.php` para mostrar la nueva columna "Pedido" con su `id_pedido` correspondiente.

Esto permite una referencia cruzada rápida entre una venta y el pedido original que la generó.