### PR TITLE
feat: Añadir campo 'controlar stock' a productos

### DIFF
--- a/backend.log
+++ b/backend.log
@@ -1,1 +1,1 @@
-[Tue Oct  7 14:40:11 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8081) started
+[Wed Oct  8 22:48:28 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8081) started

--- a/backend/api/v1/productos.php
+++ b/backend/api/v1/productos.php
@@ -20,6 +20,8 @@ switch ($request_method) {
             $product_id = intval($_GET["id"]);
             $product_data = $product->readOne($product_id);
             if ($product_data) {
+                // Convertir el valor de controlar_stock a booleano para consistencia en JSON
+                $product_data['controlar_stock'] = (bool)$product_data['controlar_stock'];
                 http_response_code(200);
                 echo json_encode($product_data);
             } else {
@@ -35,6 +37,9 @@ switch ($request_method) {
             if (!empty($_GET['precio'])) $filters['precio'] = $_GET['precio'];
             if (!empty($_GET['categoria_nombre'])) $filters['categoria_nombre'] = $_GET['categoria_nombre'];
             if (!empty($_GET['estado'])) $filters['estado'] = $_GET['estado'];
+            if (isset($_GET['controlar_stock']) && $_GET['controlar_stock'] !== '') {
+                 $filters['controlar_stock'] = $_GET['controlar_stock'];
+            }
 
             handleGetAllProducts($product, $filters);
         }
@@ -43,7 +48,10 @@ switch ($request_method) {
     case 'POST':
         $data = json_decode(file_get_contents("php://input"));
         if (!empty($data->nombre) && isset($data->precio) && !empty($data->estado)) {
-            $stmt = $product->create($data->nombre, $data->descripcion, $data->precio, $data->id_categoria, $data->estado);
+            // Asignar controlar_stock, por defecto es false si no se envía
+            $controlar_stock = isset($data->controlar_stock) ? (bool)$data->controlar_stock : false;
+
+            $stmt = $product->create($data->nombre, $data->descripcion, $data->precio, $data->id_categoria, $data->estado, $controlar_stock);
             if ($stmt) {
                 $new_product = $stmt->fetch(PDO::FETCH_ASSOC);
                 http_response_code(201); // Created
@@ -61,7 +69,10 @@ switch ($request_method) {
     case 'PUT':
         $data = json_decode(file_get_contents("php://input"));
         if (!empty($data->id) && !empty($data->nombre) && isset($data->precio) && !empty($data->estado)) {
-            if ($product->update($data->id, $data->nombre, $data->descripcion, $data->precio, $data->id_categoria, $data->estado)) {
+            // Asignar controlar_stock, por defecto es false si no se envía
+            $controlar_stock = isset($data->controlar_stock) ? (bool)$data->controlar_stock : false;
+
+            if ($product->update($data->id, $data->nombre, $data->descripcion, $data->precio, $data->id_categoria, $data->estado, $controlar_stock)) {
                 http_response_code(200);
                 echo json_encode(array("message" => "Producto actualizado."));
             } else {
@@ -113,9 +124,10 @@ function handleGetAllProducts($product, $filters = []) {
     $num = count($records);
 
     if ($num > 0) {
-        // Asegurarse de que la descripción se decodifique correctamente
+        // Asegurarse de que la descripción se decodifique y controlar_stock sea booleano
         $decoded_records = array_map(function($row) {
             $row['descripcion'] = html_entity_decode($row['descripcion']);
+            $row['controlar_stock'] = (bool)$row['controlar_stock'];
             return $row;
         }, $records);
 

--- a/backend/models/Product.php
+++ b/backend/models/Product.php
@@ -15,7 +15,7 @@ class Product {
      * @return PDOStatement
      */
     public function readAll($filters = [], $page = 1, $page_size = 12) {
-        $query = "CALL sp_getAllProducts(:id, :nombre, :descripcion, :precio, :categoria_nombre, :estado, :page_number, :page_size)";
+        $query = "CALL sp_getAllProducts(:id, :nombre, :descripcion, :precio, :categoria_nombre, :estado, :controlar_stock, :page_number, :page_size)";
         $stmt = $this->conn->prepare($query);
 
         // Asignar valores de los filtros, usando null si no están definidos
@@ -25,6 +25,7 @@ class Product {
         $precio = $filters['precio'] ?? null;
         $categoria_nombre = $filters['categoria_nombre'] ?? null;
         $estado = $filters['estado'] ?? null;
+        $controlar_stock = isset($filters['controlar_stock']) && $filters['controlar_stock'] !== '' ? filter_var($filters['controlar_stock'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : null;
 
         // Enlazar parámetros
         $stmt->bindValue(':id', $id, $id === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
@@ -33,6 +34,7 @@ class Product {
         $stmt->bindValue(':precio', $precio, $precio === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
         $stmt->bindValue(':categoria_nombre', $categoria_nombre, $categoria_nombre === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
         $stmt->bindValue(':estado', $estado, $estado === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':controlar_stock', $controlar_stock, $controlar_stock === null ? PDO::PARAM_NULL : PDO::PARAM_BOOL);
         $stmt->bindValue(':page_number', $page, PDO::PARAM_INT);
         $stmt->bindValue(':page_size', $page_size, PDO::PARAM_INT);
 
@@ -41,7 +43,7 @@ class Product {
     }
 
     public function countAll($filters = []) {
-        $query = "CALL sp_countAllProducts(:id, :nombre, :descripcion, :precio, :categoria_nombre, :estado)";
+        $query = "CALL sp_countAllProducts(:id, :nombre, :descripcion, :precio, :categoria_nombre, :estado, :controlar_stock)";
         $stmt = $this->conn->prepare($query);
 
         // Asignar valores de los filtros, usando null si no están definidos
@@ -51,6 +53,7 @@ class Product {
         $precio = $filters['precio'] ?? null;
         $categoria_nombre = $filters['categoria_nombre'] ?? null;
         $estado = $filters['estado'] ?? null;
+        $controlar_stock = isset($filters['controlar_stock']) && $filters['controlar_stock'] !== '' ? filter_var($filters['controlar_stock'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : null;
 
         // Enlazar parámetros
         $stmt->bindValue(':id', $id, $id === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
@@ -59,6 +62,7 @@ class Product {
         $stmt->bindValue(':precio', $precio, $precio === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
         $stmt->bindValue(':categoria_nombre', $categoria_nombre, $categoria_nombre === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
         $stmt->bindValue(':estado', $estado, $estado === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $stmt->bindValue(':controlar_stock', $controlar_stock, $controlar_stock === null ? PDO::PARAM_NULL : PDO::PARAM_BOOL);
 
         $stmt->execute();
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -69,8 +73,8 @@ class Product {
      * Crea un nuevo producto.
      * @return PDOStatement|false
      */
-    public function create($nombre, $descripcion, $precio, $id_categoria, $estado) {
-        $query = "CALL sp_createProduct(:nombre, :descripcion, :precio, :id_categoria, :estado)";
+    public function create($nombre, $descripcion, $precio, $id_categoria, $estado, $controlar_stock) {
+        $query = "CALL sp_createProduct(:nombre, :descripcion, :precio, :id_categoria, :estado, :controlar_stock)";
         $stmt = $this->conn->prepare($query);
 
         // Limpiar datos
@@ -79,6 +83,7 @@ class Product {
         $precio = htmlspecialchars(strip_tags($precio));
         $id_categoria = htmlspecialchars(strip_tags($id_categoria));
         $estado = htmlspecialchars(strip_tags($estado));
+        $controlar_stock = (bool)$controlar_stock;
 
         // Enlazar parámetros
         $stmt->bindParam(':nombre', $nombre);
@@ -86,6 +91,7 @@ class Product {
         $stmt->bindParam(':precio', $precio);
         $stmt->bindParam(':id_categoria', $id_categoria);
         $stmt->bindParam(':estado', $estado);
+        $stmt->bindParam(':controlar_stock', $controlar_stock, PDO::PARAM_BOOL);
 
         if ($stmt->execute()) {
             return $stmt;
@@ -109,8 +115,8 @@ class Product {
      * Actualiza un producto existente.
      * @return bool
      */
-    public function update($id, $nombre, $descripcion, $precio, $id_categoria, $estado) {
-        $query = "CALL sp_updateProduct(:id, :nombre, :descripcion, :precio, :id_categoria, :estado)";
+    public function update($id, $nombre, $descripcion, $precio, $id_categoria, $estado, $controlar_stock) {
+        $query = "CALL sp_updateProduct(:id, :nombre, :descripcion, :precio, :id_categoria, :estado, :controlar_stock)";
         $stmt = $this->conn->prepare($query);
 
         // Limpiar datos
@@ -120,6 +126,7 @@ class Product {
         $precio = htmlspecialchars(strip_tags($precio));
         $id_categoria = htmlspecialchars(strip_tags($id_categoria));
         $estado = htmlspecialchars(strip_tags($estado));
+        $controlar_stock = (bool)$controlar_stock;
 
         // Enlazar parámetros
         $stmt->bindParam(':id', $id);
@@ -128,6 +135,7 @@ class Product {
         $stmt->bindParam(':precio', $precio);
         $stmt->bindParam(':id_categoria', $id_categoria);
         $stmt->bindParam(':estado', $estado);
+        $stmt->bindParam(':controlar_stock', $controlar_stock, PDO::PARAM_BOOL);
 
         if ($stmt->execute()) {
             return true;

--- a/frontend.log
+++ b/frontend.log
@@ -1,1 +1,1 @@
-[Tue Oct  7 14:40:11 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8000) started
+[Wed Oct  8 22:48:41 2025] PHP 8.3.6 Development Server (http://0.0.0.0:8000) started

--- a/frontend_web/producto_form.php
+++ b/frontend_web/producto_form.php
@@ -70,6 +70,10 @@ $categories = getAPIdata('categorias.php');
                         </select>
                     </div>
                     <div class="form-group">
+                        <label for="controlar_stock">Controlar Stock</label>
+                        <input type="checkbox" id="controlar_stock" name="controlar_stock" value="1" <?php echo (isset($product_data['controlar_stock']) && $product_data['controlar_stock']) ? 'checked' : ''; ?>>
+                    </div>
+                    <div class="form-group">
                         <label for="estado">Estado</label>
                         <select id="estado" name="estado" required>
                             <option value="activo" <?php echo (isset($product_data['estado']) && $product_data['estado'] == 'activo') ? 'selected' : ''; ?>>Activo</option>

--- a/frontend_web/producto_handler.php
+++ b/frontend_web/producto_handler.php
@@ -16,7 +16,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         'descripcion' => $_POST['descripcion'] ?? '',
         'precio' => $_POST['precio'] ?? '',
         'id_categoria' => $_POST['id_categoria'] ?? null,
-        'estado' => $_POST['estado'] ?? ''
+        'estado' => $_POST['estado'] ?? '',
+        'controlar_stock' => isset($_POST['controlar_stock']) ? true : false
     ];
 
     $ch = curl_init();

--- a/frontend_web/productos.php
+++ b/frontend_web/productos.php
@@ -43,6 +43,9 @@ if (!empty($_GET['categoria_nombre'])) {
 if (!empty($_GET['estado'])) {
     $filters['estado'] = $_GET['estado'];
 }
+if (isset($_GET['controlar_stock']) && $_GET['controlar_stock'] !== '') {
+    $filters['controlar_stock'] = $_GET['controlar_stock'];
+}
 if (!empty($_GET['page'])) {
     $filters['page'] = $_GET['page'];
 }
@@ -101,6 +104,11 @@ $categories = getCategories();
                             <option value="activo" <?php echo (isset($_GET['estado']) && $_GET['estado'] == 'activo') ? 'selected' : ''; ?>>Activo</option>
                             <option value="inactivo" <?php echo (isset($_GET['estado']) && $_GET['estado'] == 'inactivo') ? 'selected' : ''; ?>>Inactivo</option>
                         </select>
+                        <select name="controlar_stock">
+                            <option value="">Controlar Stock</option>
+                            <option value="1" <?php echo (isset($_GET['controlar_stock']) && $_GET['controlar_stock'] == '1') ? 'selected' : ''; ?>>Sí</option>
+                            <option value="0" <?php echo (isset($_GET['controlar_stock']) && $_GET['controlar_stock'] === '0') ? 'selected' : ''; ?>>No</option>
+                        </select>
                         <button type="submit" class="btn">Filtrar</button>
                     </div>
                 </form>
@@ -115,6 +123,7 @@ $categories = getCategories();
                             <th>Precio</th>
                             <th>Categoría</th>
                             <th>Estado</th>
+                            <th>Controlar Stock</th>
                             <th>Acciones</th>
                         </tr>
                     </thead>
@@ -132,6 +141,11 @@ $categories = getCategories();
                                             <?php echo htmlspecialchars($product['estado']); ?>
                                         </span>
                                     </td>
+                                    <td data-label="Controlar Stock">
+                                        <span class="status status-<?php echo $product['controlar_stock'] ? 'active' : 'inactive'; ?>">
+                                            <?php echo $product['controlar_stock'] ? 'Sí' : 'No'; ?>
+                                        </span>
+                                    </td>
                                     <td data-label="Acciones" class="actions-cell">
                                         <a href="producto_form.php?id=<?php echo $product['id']; ?>" class="btn btn-edit">Editar</a>
                                         <a href="producto_delete_handler.php?id=<?php echo $product['id']; ?>" class="btn btn-delete" onclick="return confirm('¿Estás seguro de que quieres eliminar este producto?');">Eliminar</a>
@@ -140,7 +154,7 @@ $categories = getCategories();
                             <?php endforeach; ?>
                         <?php else: ?>
                             <tr>
-                                <td colspan="7">No se encontraron productos. La base de datos podría estar vacía o no hay productos que coincidan con los filtros.</td>
+                                <td colspan="8">No se encontraron productos. La base de datos podría estar vacía o no hay productos que coincidan con los filtros.</td>
                             </tr>
                         <?php endif; ?>
                     </tbody>
@@ -176,4 +190,3 @@ $categories = getCategories();
         </div>
     </main>
 </div>
-

--- a/migrations/sc_003_add_controlar_stock_to_productos.sql
+++ b/migrations/sc_003_add_controlar_stock_to_productos.sql
@@ -1,0 +1,1 @@
+ALTER TABLE productos ADD COLUMN controlar_stock BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/sc_004_update_product_sprocs.sql
+++ b/migrations/sc_004_update_product_sprocs.sql
@@ -1,0 +1,147 @@
+USE restaurante_db;
+
+-- Eliminar procedimientos existentes para poder recrearlos
+DROP PROCEDURE IF EXISTS sp_createProduct;
+DROP PROCEDURE IF EXISTS sp_readOneProduct;
+DROP PROCEDURE IF EXISTS sp_updateProduct;
+DROP PROCEDURE IF EXISTS sp_getAllProducts;
+DROP PROCEDURE IF EXISTS sp_countAllProducts;
+
+DELIMITER $$
+
+--
+-- Procedimiento para crear un nuevo producto
+--
+CREATE PROCEDURE `sp_createProduct`(
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_precio DECIMAL(10, 2),
+    IN p_id_categoria INT,
+    IN p_estado ENUM('activo', 'inactivo'),
+    IN p_controlar_stock BOOLEAN
+)
+BEGIN
+    INSERT INTO productos (nombre, descripcion, precio, id_categoria, estado, controlar_stock)
+    VALUES (p_nombre, p_descripcion, p_precio, p_id_categoria, p_estado, p_controlar_stock);
+    SELECT LAST_INSERT_ID() AS id;
+END$$
+
+--
+-- Procedimiento para leer un solo producto por su ID
+--
+CREATE PROCEDURE `sp_readOneProduct`(IN p_id INT)
+BEGIN
+    SELECT
+        p.id,
+        p.nombre,
+        p.descripcion,
+        p.precio,
+        p.id_categoria,
+        p.estado,
+        p.controlar_stock,
+        c.nombre AS categoria_nombre,
+        c.tipo_categoria AS categoria_tipo
+    FROM
+        productos p
+        LEFT JOIN categorias_producto c ON p.id_categoria = c.id
+    WHERE
+        p.id = p_id;
+END$$
+
+--
+-- Procedimiento para actualizar un producto existente
+--
+CREATE PROCEDURE `sp_updateProduct`(
+    IN p_id INT,
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_precio DECIMAL(10, 2),
+    IN p_id_categoria INT,
+    IN p_estado ENUM('activo', 'inactivo'),
+    IN p_controlar_stock BOOLEAN
+)
+BEGIN
+    UPDATE productos
+    SET
+        nombre = p_nombre,
+        descripcion = p_descripcion,
+        precio = p_precio,
+        id_categoria = p_id_categoria,
+        estado = p_estado,
+        controlar_stock = p_controlar_stock
+    WHERE
+        id = p_id;
+END$$
+
+--
+-- Procedimiento para leer todos los productos con filtros y paginación
+--
+CREATE PROCEDURE `sp_getAllProducts`(
+    IN p_id INT,
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_precio DECIMAL(10, 2),
+    IN p_categoria_nombre VARCHAR(100),
+    IN p_estado VARCHAR(10),
+    IN p_controlar_stock BOOLEAN,
+    IN p_page_number INT,
+    IN p_page_size INT
+)
+BEGIN
+    DECLARE v_offset INT;
+    SET v_offset = (p_page_number - 1) * p_page_size;
+
+    SELECT
+        p.id,
+        p.nombre,
+        p.descripcion,
+        p.precio,
+        p.estado,
+        p.controlar_stock,
+        c.nombre AS categoria_nombre,
+        c.tipo_categoria AS categoria_tipo
+    FROM
+        productos p
+        LEFT JOIN categorias_producto c ON p.id_categoria = c.id
+    WHERE
+        (p_id IS NULL OR p.id = p_id) AND
+        (p_nombre IS NULL OR p.nombre LIKE CONCAT('%', p_nombre, '%')) AND
+        (p_descripcion IS NULL OR p.descripcion LIKE CONCAT('%', p_descripcion, '%')) AND
+        (p_precio IS NULL OR p.precio = p_precio) AND
+        (p_categoria_nombre IS NULL OR c.nombre = p_categoria_nombre) AND
+        (p_estado IS NULL OR p.estado = p_estado) AND
+        (p_controlar_stock IS NULL OR p.controlar_stock = p_controlar_stock)
+    ORDER BY
+        p.nombre
+    LIMIT p_page_size OFFSET v_offset;
+END$$
+
+--
+-- Procedimiento para contar todos los productos con filtros
+--
+CREATE PROCEDURE `sp_countAllProducts`(
+    IN p_id INT,
+    IN p_nombre VARCHAR(100),
+    IN p_descripcion TEXT,
+    IN p_precio DECIMAL(10, 2),
+    IN p_categoria_nombre VARCHAR(100),
+    IN p_estado VARCHAR(10),
+    IN p_controlar_stock BOOLEAN
+)
+BEGIN
+    SELECT
+        COUNT(*) AS total_records
+    FROM
+        productos p
+        LEFT JOIN categorias_producto c ON p.id_categoria = c.id
+    WHERE
+        (p_id IS NULL OR p.id = p_id) AND
+        (p_nombre IS NULL OR p.nombre LIKE CONCAT('%', p_nombre, '%')) AND
+        (p_descripcion IS NULL OR p.descripcion LIKE CONCAT('%', p_descripcion, '%')) AND
+        (p_precio IS NULL OR p.precio = p_precio) AND
+        (p_categoria_nombre IS NULL OR c.nombre = p_categoria_nombre) AND
+        (p_estado IS NULL OR p.estado = p_estado) AND
+        (p_controlar_stock IS NULL OR p.controlar_stock = p_controlar_stock);
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
Se ha añadido un nuevo campo de tipo checkbox llamado "controlar stock" a la sección de productos.

Los cambios incluyen:
- **Base de datos:** Se ha creado un nuevo script de migración (`sc_003_add_controlar_stock_to_productos.sql`) para añadir la columna `controlar_stock` a la tabla `productos`. También se han actualizado los procedimientos almacenados correspondientes en `sc_004_update_product_sprocs.sql`.
- **Backend:** Se ha modificado el modelo `Product.php` y el endpoint de la API `productos.php` para manejar la lógica del nuevo campo en las operaciones de creación, actualización y consulta.
- **Frontend:** Se ha añadido el checkbox "Controlar Stock" en el formulario de productos (`producto_form.php`), se ha actualizado el manejador (`producto_handler.php`) y se ha modificado la página principal de productos (`productos.php`) para mostrar y filtrar por el nuevo campo.