### PR TITLE
feat: Generar movimiento de salida al procesar venta

### DIFF
--- a/backend/api/v1/procesar_venta.php
+++ b/backend/api/v1/procesar_venta.php
@@ -4,9 +4,16 @@ header("Content-Type: application/json; charset=UTF-8");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
 
+<?php
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: POST");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
 include_once __DIR__ . '/../../config/database.php';
 include_once __DIR__ . '/../../models/Venta.php';
 include_once __DIR__ . '/../../models/AperturaCierre.php';
+include_once __DIR__ . '/../../models/Movimiento.php'; // Incluir el nuevo modelo
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
@@ -26,19 +33,23 @@ if (
     exit;
 }
 
+$db_connection = null;
 try {
-    $db = new PDO(DB_DSN, DB_USER, DB_PASS);
-    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $db_connection = new PDO(DB_DSN, DB_USER, DB_PASS);
+    $db_connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
     http_response_code(503); // Service Unavailable
     echo json_encode(["message" => "No se puede conectar a la base de datos: " . $e->getMessage()]);
     exit();
 }
-$venta = new Venta($db);
-$apertura_cierre = new AperturaCierre(); // No necesita $db porque usa el Singleton
+
+// Instanciar modelos
+$venta = new Venta($db_connection);
+$movimiento = new Movimiento(); // Usa el Singleton de Database
+$apertura_cierre = new AperturaCierre();
 
 session_start();
-$id_usuario_cajero = $_SESSION['user_id'] ?? 0; // Asumimos que el ID del usuario está en la sesión
+$id_usuario_cajero = $_SESSION['user_id'] ?? 0;
 if (empty($id_usuario_cajero)) {
     http_response_code(401); // Unauthorized
     echo json_encode(["message" => "No autorizado. Inicie sesión como cajero."]);
@@ -46,14 +57,21 @@ if (empty($id_usuario_cajero)) {
 }
 
 try {
-    // Primero, verificar si ya existe una venta para este pedido
+    // 1. Verificar si ya existe una venta para este pedido
     if ($venta->ventaExistePorPedido($data->id_pedido)) {
         http_response_code(409); // Conflict
         echo json_encode(["message" => "Este pedido ya tiene una venta generada. No se puede procesar nuevamente."]);
         exit;
     }
 
-    // Validación de apertura de caja
+    // 2. Verificar si ya existe un movimiento de salida para este pedido
+    if ($movimiento->verificarMovimientoPorPedido($data->id_pedido)) {
+        http_response_code(409); // Conflict
+        echo json_encode(["message" => "Este pedido ya tiene un movimiento de salida. No se puede procesar nuevamente."]);
+        exit;
+    }
+
+    // 3. Validación de apertura de caja
     $fecha_actual = date('Y-m-d');
     if (!$apertura_cierre->verificarAperturaActiva($fecha_actual)) {
         http_response_code(403); // Forbidden
@@ -61,8 +79,11 @@ try {
         exit;
     }
 
-    // CORRECCIÓN: Obtener el id_cliente desde el pedido original en la base de datos.
-    $stmt = $db->prepare("SELECT id_cliente FROM pedidos WHERE id = :id_pedido");
+    // Iniciar transacción
+    $db_connection->beginTransaction();
+
+    // 4. Obtener el id_cliente desde el pedido original en la base de datos.
+    $stmt = $db_connection->prepare("SELECT id_cliente FROM pedidos WHERE id = :id_pedido");
     $stmt->bindParam(':id_pedido', $data->id_pedido, PDO::PARAM_INT);
     $stmt->execute();
     $pedido = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -72,27 +93,43 @@ try {
     }
     $id_cliente = $pedido['id_cliente'] ?? null;
 
-    // Llamar al procedimiento almacenado para crear la venta
-    $result = $venta->crearVentaDesdePedido(
+    // 5. Crear la venta
+    $result_venta = $venta->crearVentaDesdePedido(
         $data->id_pedido,
         $id_usuario_cajero,
         $data->id_tipo_documento_venta,
         $data->id_serie_documento,
-        $id_cliente // Usar el id_cliente obtenido de la BD
+        $id_cliente
     );
 
-    if ($result && isset($result['id_venta'])) {
-        http_response_code(201); // Created
-        echo json_encode([
-            "message" => "Venta generada con éxito.",
-            "id_venta" => $result['id_venta'],
-            "numero_documento" => $result['numero_documento']
-        ]);
-    } else {
-        throw new Exception($result['error'] ?? "No se pudo crear la venta.");
+    if (!$result_venta || !isset($result_venta['id_venta'])) {
+        throw new Exception($result_venta['error'] ?? "No se pudo crear la venta.");
     }
+
+    // 6. Crear el movimiento de salida
+    $result_movimiento = $movimiento->crearMovimientoSalidaPorVenta($data->id_pedido);
+
+    if (!$result_movimiento || !isset($result_movimiento['id_movimiento'])) {
+        throw new Exception("No se pudo crear el movimiento de salida.");
+    }
+
+    // Si todo fue bien, confirmar la transacción
+    $db_connection->commit();
+
+    http_response_code(201); // Created
+    echo json_encode([
+        "message" => "Venta y movimiento de salida generados con éxito.",
+        "id_venta" => $result_venta['id_venta'],
+        "numero_documento" => $result_venta['numero_documento'],
+        "id_movimiento" => $result_movimiento['id_movimiento']
+    ]);
+
 } catch (Exception $e) {
+    // Si algo falló, revertir la transacción
+    if ($db_connection->inTransaction()) {
+        $db_connection->rollBack();
+    }
     http_response_code(500); // Internal Server Error
-    echo json_encode(["message" => "Error al generar la venta: " . $e->getMessage()]);
+    echo json_encode(["message" => "Error al procesar la operación: " . $e->getMessage()]);
 }
 ?>

--- a/backend/models/Movimiento.php
+++ b/backend/models/Movimiento.php
@@ -107,5 +107,23 @@ class Movimiento {
         $stmt->bindParam(':p_id_movimiento', $id);
         return $stmt->execute();
     }
+
+    public function verificarMovimientoPorPedido($id_pedido) {
+        $stmt = $this->conn->prepare("CALL sp_verificar_movimiento_por_pedido(:p_id_pedido)");
+        $stmt->bindParam(':p_id_pedido', $id_pedido, PDO::PARAM_INT);
+        $stmt->execute();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+        return $result['movimiento_existente'] > 0;
+    }
+
+    public function crearMovimientoSalidaPorVenta($id_pedido) {
+        $stmt = $this->conn->prepare("CALL sp_crear_movimiento_salida_por_venta(:p_id_pedido)");
+        $stmt->bindParam(':p_id_pedido', $id_pedido, PDO::PARAM_INT);
+        $stmt->execute();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->closeCursor();
+        return $result;
+    }
 }
 ?>

--- a/database/database.sql
+++ b/database/database.sql
@@ -766,7 +766,7 @@ DELIMITER $$
 -- Create procedure `sp_updateIdentityDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateIdentityDocumentType (IN p_id int,
 IN p_codigo varchar(2),
 IN p_nombre varchar(100),
@@ -786,7 +786,7 @@ $$
 -- Create procedure `sp_getOneIdentityDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOneIdentityDocumentType (IN p_id int)
 BEGIN
   SELECT
@@ -804,7 +804,7 @@ $$
 -- Create procedure `sp_getAllIdentityDocumentTypes`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllIdentityDocumentTypes ()
 BEGIN
   SELECT
@@ -822,7 +822,7 @@ $$
 -- Create procedure `sp_deleteIdentityDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteIdentityDocumentType (IN p_id int)
 BEGIN
   DELETE
@@ -835,7 +835,7 @@ $$
 -- Create procedure `sp_createIdentityDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createIdentityDocumentType (IN p_codigo varchar(2),
 IN p_nombre varchar(100),
 IN p_descripcion text)
@@ -891,7 +891,7 @@ DELIMITER $$
 -- Create procedure `sp_updateProveedor`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_updateProveedor (IN p_id int,
 IN p_id_tipo_documento_identidad int,
 IN p_numero_documento varchar(20),
@@ -919,7 +919,7 @@ $$
 -- Create procedure `sp_getOneProveedor`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_getOneProveedor (IN p_id int)
 BEGIN
   SELECT
@@ -941,7 +941,7 @@ $$
 -- Create procedure `sp_getAllProveedores`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_getAllProveedores ()
 BEGIN
   SELECT
@@ -965,7 +965,7 @@ $$
 -- Create procedure `sp_deleteProveedor`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_deleteProveedor (IN p_id int)
 BEGIN
   UPDATE `proveedores`
@@ -978,7 +978,7 @@ $$
 -- Create procedure `sp_createProveedor`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_createProveedor (IN p_id_tipo_documento_identidad int,
 IN p_numero_documento varchar(20),
 IN p_nombres_apellidos varchar(200),
@@ -1043,7 +1043,7 @@ DELIMITER $$
 -- Create procedure `sp_updateCliente`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateCliente (IN p_id int,
 IN p_id_tipo_documento_identidad int,
 IN p_numero_documento varchar(20),
@@ -1071,7 +1071,7 @@ $$
 -- Create procedure `sp_searchClientes`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_searchClientes (IN p_search_term varchar(200))
 BEGIN
   SELECT
@@ -1098,7 +1098,7 @@ $$
 -- Create procedure `sp_getOneCliente`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOneCliente (IN p_id int)
 BEGIN
   SELECT
@@ -1120,7 +1120,7 @@ $$
 -- Create procedure `sp_getAllClientes`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllClientes ()
 BEGIN
   SELECT
@@ -1145,7 +1145,7 @@ $$
 -- Create procedure `sp_deleteCliente`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteCliente (IN p_id int)
 BEGIN
   DELETE
@@ -1158,7 +1158,7 @@ $$
 -- Create procedure `sp_createCliente`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createCliente (IN p_id_tipo_documento_identidad int,
 IN p_numero_documento varchar(20),
 IN p_nombres_apellidos varchar(200),
@@ -1217,7 +1217,7 @@ DELIMITER $$
 -- Create procedure `sp_getAllRoles`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllRoles ()
 BEGIN
   SELECT
@@ -1270,7 +1270,7 @@ DELIMITER $$
 -- Create procedure `sp_updateUser`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateUser (IN p_id int, IN p_nombre_completo varchar(100), IN p_email varchar(100), IN p_id_rol int, IN p_activo boolean, IN p_password_hash varchar(255))
 BEGIN
   UPDATE usuarios
@@ -1292,7 +1292,7 @@ $$
 -- Create procedure `sp_readOneUser`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_readOneUser (IN p_id int)
 BEGIN
   SELECT
@@ -1311,7 +1311,7 @@ $$
 -- Create procedure `sp_getUsersByRole`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getUsersByRole (IN p_role_name varchar(50))
 BEGIN
   SELECT
@@ -1332,7 +1332,7 @@ $$
 -- Create procedure `sp_getUserByUsername`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getUserByUsername (IN p_username varchar(50))
 BEGIN
   SELECT
@@ -1354,7 +1354,7 @@ $$
 -- Create procedure `sp_getAllUsers`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllUsers ()
 BEGIN
   SELECT
@@ -1376,7 +1376,7 @@ $$
 -- Create procedure `sp_deleteUser`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteUser (IN p_id int)
 BEGIN
   UPDATE usuarios
@@ -1389,7 +1389,7 @@ $$
 -- Create procedure `sp_createUser`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createUser (IN p_username varchar(50), IN p_nombre_completo varchar(100), IN p_email varchar(100), IN p_password_hash varchar(255), IN p_id_rol int)
 BEGIN
   INSERT INTO usuarios (username, nombre_completo, email, password_hash, id_rol)
@@ -1496,7 +1496,7 @@ DELIMITER $$
 -- Create procedure `sp_verificarAperturaActiva`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_verificarAperturaActiva (IN p_fecha date)
 BEGIN
   DECLARE v_apertura_count int;
@@ -1532,7 +1532,7 @@ $$
 -- Create procedure `sp_verificar_cierre_por_fecha`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_verificar_cierre_por_fecha (IN p_fecha date)
 BEGIN
   DECLARE cierre_existente int DEFAULT 0;
@@ -1552,7 +1552,7 @@ $$
 -- Create procedure `sp_updateTipoMovimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_updateTipoMovimiento (IN p_id int,
 IN p_tipo char(1),
 IN p_codigo char(3),
@@ -1572,7 +1572,7 @@ $$
 -- Create procedure `sp_getOneTipoMovimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_getOneTipoMovimiento (IN p_id int)
 BEGIN
   SELECT
@@ -1590,7 +1590,7 @@ $$
 -- Create procedure `sp_getAllTiposMovimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_getAllTiposMovimiento (IN p_descripcion varchar(255),
 IN p_estado varchar(20))
 BEGIN
@@ -1616,7 +1616,7 @@ $$
 -- Create procedure `sp_deleteTipoMovimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_deleteTipoMovimiento (IN p_id int)
 BEGIN
   UPDATE tipo_movimiento
@@ -1629,7 +1629,7 @@ $$
 -- Create procedure `sp_createTipoMovimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_createTipoMovimiento (IN p_tipo char(1),
 IN p_codigo char(3),
 IN p_descripcion varchar(1000))
@@ -1669,7 +1669,7 @@ DELIMITER $$
 -- Create procedure `sp_leer_almacenes`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_leer_almacenes (IN p_nombre varchar(255),
 IN p_estado boolean,
 IN p_offset int,
@@ -1696,7 +1696,7 @@ $$
 -- Create procedure `sp_leer_almacen_por_id`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_leer_almacen_por_id (IN p_id int)
 BEGIN
   SELECT
@@ -1713,7 +1713,7 @@ $$
 -- Create procedure `sp_desactivar_almacen`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_desactivar_almacen (IN p_id int)
 BEGIN
   UPDATE `almacenes`
@@ -1727,7 +1727,7 @@ $$
 -- Create procedure `sp_crear_almacen`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_crear_almacen (IN p_nombre varchar(255),
 IN p_predeterminado boolean)
 BEGIN
@@ -1749,7 +1749,7 @@ $$
 -- Create procedure `sp_contar_almacenes`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_contar_almacenes (IN p_nombre varchar(255),
 IN p_estado boolean)
 BEGIN
@@ -1768,7 +1768,7 @@ $$
 -- Create procedure `sp_actualizar_almacen`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_actualizar_almacen (IN p_id int,
 IN p_nombre varchar(255),
 IN p_estado boolean,
@@ -1815,7 +1815,7 @@ DELIMITER $$
 -- Create procedure `sp_updateTable`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateTable (IN p_id int, IN p_numero_mesa varchar(10), IN p_capacidad int, IN p_estado enum ('disponible', 'ocupada', 'reservada', 'mantenimiento'), IN p_es_libre boolean)
 BEGIN
   UPDATE mesas
@@ -1831,7 +1831,7 @@ $$
 -- Create procedure `sp_readOneTable`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_readOneTable (IN p_id int)
 BEGIN
   SELECT
@@ -1849,7 +1849,7 @@ $$
 -- Create procedure `sp_getTablesByLibreStatus`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getTablesByLibreStatus (IN p_es_libre boolean)
 BEGIN
   SELECT
@@ -1867,7 +1867,7 @@ $$
 -- Create procedure `sp_getAllTables`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllTables ()
 BEGIN
   SELECT
@@ -1885,7 +1885,7 @@ $$
 -- Create procedure `sp_deleteTable`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteTable (IN p_id int)
 BEGIN
   DELETE
@@ -1898,7 +1898,7 @@ $$
 -- Create procedure `sp_createTable`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createTable (IN p_numero_mesa varchar(10), IN p_capacidad int, IN p_estado enum ('disponible', 'ocupada', 'reservada', 'mantenimiento'), IN p_es_libre boolean)
 BEGIN
   INSERT INTO mesas (numero_mesa, capacidad, estado, es_libre)
@@ -1944,7 +1944,7 @@ DELIMITER $$
 -- Create procedure `sp_updateReservation`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateReservation (IN p_id int,
 IN p_id_mesa int,
 IN p_nombre_cliente varchar(100),
@@ -1972,7 +1972,7 @@ $$
 -- Create procedure `sp_readOneReservation`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_readOneReservation (IN p_id int)
 BEGIN
   SELECT
@@ -1994,7 +1994,7 @@ $$
 -- Create procedure `sp_getAllReservations`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllReservations ()
 BEGIN
   SELECT
@@ -2016,7 +2016,7 @@ $$
 -- Create procedure `sp_createReservation`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createReservation (IN p_id_mesa int,
 IN p_nombre_cliente varchar(100),
 IN p_telefono_cliente varchar(20),
@@ -2036,7 +2036,7 @@ $$
 -- Create procedure `sp_cancelReservation`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_cancelReservation (IN p_id int)
 BEGIN
   UPDATE reservas
@@ -2077,7 +2077,7 @@ DELIMITER $$
 -- Create procedure `sp_updateSaleDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateSaleDocumentType (IN p_id int,
 IN p_codigo varchar(2),
 IN p_nombre varchar(100),
@@ -2097,7 +2097,7 @@ $$
 -- Create procedure `sp_getOneSaleDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOneSaleDocumentType (IN p_id int)
 BEGIN
   SELECT
@@ -2115,7 +2115,7 @@ $$
 -- Create procedure `sp_getAllTipoDocumentoVenta`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllTipoDocumentoVenta ()
 BEGIN
   SELECT
@@ -2132,7 +2132,7 @@ $$
 -- Create procedure `sp_getAllSaleDocumentTypes`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllSaleDocumentTypes ()
 BEGIN
   SELECT
@@ -2150,7 +2150,7 @@ $$
 -- Create procedure `sp_deleteSaleDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteSaleDocumentType (IN p_id int)
 BEGIN
   DELETE
@@ -2163,7 +2163,7 @@ $$
 -- Create procedure `sp_createSaleDocumentType`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createSaleDocumentType (IN p_codigo varchar(2),
 IN p_nombre varchar(100),
 IN p_descripcion text)
@@ -2207,7 +2207,7 @@ DELIMITER $$
 -- Create procedure `sp_updateSerie`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateSerie (IN p_id int,
 IN p_id_tipo_documento int,
 IN p_serie varchar(10),
@@ -2225,7 +2225,7 @@ $$
 -- Create procedure `sp_getOneSerie`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOneSerie (IN p_id int)
 BEGIN
   SELECT
@@ -2245,7 +2245,7 @@ $$
 -- Create procedure `sp_getAllSeries`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllSeries ()
 BEGIN
   SELECT
@@ -2265,7 +2265,7 @@ $$
 -- Create procedure `sp_deleteSerie`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteSerie (IN p_id int)
 BEGIN
   DELETE
@@ -2278,7 +2278,7 @@ $$
 -- Create procedure `sp_createSerie`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createSerie (IN p_id_tipo_documento int,
 IN p_serie varchar(10))
 BEGIN
@@ -2349,7 +2349,7 @@ DELIMITER $$
 -- Create procedure `sp_updateOrderStatus`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_updateOrderStatus (IN p_id_pedido int,
 IN p_estado varchar(50))
 BEGIN
@@ -2376,7 +2376,7 @@ $$
 -- Create procedure `sp_getOrdersByStatus`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOrdersByStatus (IN p_status varchar(255))
 BEGIN
   SELECT
@@ -2402,7 +2402,7 @@ $$
 -- Create procedure `sp_getOrderDetail`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOrderDetail (IN p_id_pedido int)
 BEGIN
   SELECT
@@ -2439,7 +2439,7 @@ $$
 -- Create procedure `sp_getAvailableTables`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAvailableTables ()
 BEGIN
   SELECT
@@ -2460,7 +2460,7 @@ $$
 -- Create procedure `sp_getAllOrders`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllOrders (IN p_status varchar(255))
 BEGIN
   SELECT
@@ -2553,7 +2553,7 @@ DELIMITER $$
 -- Create procedure `sp_verificarVentaPorPedido`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_verificarVentaPorPedido (IN p_id_pedido int)
 BEGIN
   SELECT
@@ -2567,7 +2567,7 @@ $$
 -- Create procedure `sp_leer_ventas`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_leer_ventas (IN p_fecha_inicio date,
 IN p_fecha_fin date,
 IN p_estado varchar(20),
@@ -2627,7 +2627,7 @@ $$
 -- Create procedure `sp_contar_ventas`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_contar_ventas (IN p_fecha_inicio date,
 IN p_fecha_fin date,
 IN p_estado varchar(10),
@@ -2662,7 +2662,7 @@ $$
 -- Create procedure `sp_calcular_cierre`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_calcular_cierre (IN p_fecha date)
 BEGIN
   DECLARE total_movimientos decimal(10, 2);
@@ -2766,7 +2766,7 @@ DELIMITER $$
 -- Create procedure `sp_read_movimientos`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_read_movimientos (IN p_filter varchar(255),
 IN p_tipo_movimiento char(1),
 IN p_tipo_entidad char(1),
@@ -2832,7 +2832,7 @@ $$
 -- Create procedure `sp_delete_movimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_delete_movimiento (IN p_id_movimiento bigint)
 BEGIN
   DELETE
@@ -2845,7 +2845,7 @@ $$
 -- Create procedure `sp_count_movimientos`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_count_movimientos (IN p_filter varchar(255),
 IN p_tipo_movimiento char(1),
 IN p_tipo_entidad char(1),
@@ -2916,7 +2916,7 @@ DELIMITER $$
 -- Create procedure `sp_updateCategory`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateCategory (IN p_id int,
 IN p_nombre varchar(100),
 IN p_descripcion text,
@@ -2936,7 +2936,7 @@ $$
 -- Create procedure `sp_readOneCategory`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_readOneCategory (IN p_id int)
 BEGIN
   SELECT
@@ -2954,7 +2954,7 @@ $$
 -- Create procedure `sp_getAllCategories`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllCategories ()
 BEGIN
   SELECT
@@ -2972,7 +2972,7 @@ $$
 -- Create procedure `sp_deleteCategory`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteCategory (IN p_id int)
 BEGIN
   DELETE
@@ -2985,7 +2985,7 @@ $$
 -- Create procedure `sp_createCategory`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createCategory (IN p_nombre varchar(100),
 IN p_descripcion text,
 IN p_tipo_categoria enum ('Bienes', 'Servicios'))
@@ -3033,7 +3033,7 @@ DELIMITER $$
 -- Create procedure `sp_updateProduct`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_updateProduct (IN p_id int,
 IN p_nombre varchar(100),
 IN p_descripcion text,
@@ -3057,7 +3057,7 @@ $$
 -- Create procedure `sp_readOneProduct`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_readOneProduct (IN p_id int)
 BEGIN
   SELECT
@@ -3081,7 +3081,7 @@ $$
 -- Create procedure `sp_getAllProducts`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_getAllProducts (IN p_id int,
 IN p_nombre varchar(100),
 IN p_descripcion text,
@@ -3130,7 +3130,7 @@ $$
 -- Create procedure `sp_deleteProduct`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteProduct (IN p_id int)
 BEGIN
   DELETE
@@ -3143,7 +3143,7 @@ $$
 -- Create procedure `sp_createProduct`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_createProduct (IN p_nombre varchar(100),
 IN p_descripcion text,
 IN p_precio decimal(10, 2),
@@ -3162,7 +3162,7 @@ $$
 -- Create procedure `sp_countAllProducts`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_countAllProducts (IN p_id int,
 IN p_nombre varchar(100),
 IN p_descripcion text,
@@ -3268,7 +3268,7 @@ DELIMITER $$
 -- Create procedure `sp_updateOrder`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateOrder (IN p_id_pedido int,
 IN p_id_mesa int,
 IN p_id_usuario_mozo int,
@@ -3329,7 +3329,7 @@ $$
 -- Create procedure `sp_getOrderItems`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOrderItems (IN p_id_pedido int)
 BEGIN
   SELECT
@@ -3353,7 +3353,7 @@ $$
 -- Create procedure `sp_createOrder`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createOrder (IN p_id_mesa int,
 IN p_id_usuario_mozo int,
 IN p_items_json json,
@@ -3428,7 +3428,7 @@ DELIMITER $$
 -- Create procedure `sp_getDepartamentos`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getDepartamentos ()
 BEGIN
   SELECT
@@ -3469,7 +3469,7 @@ DELIMITER $$
 -- Create procedure `sp_getProvincias`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getProvincias (IN p_id_departamento varchar(2))
 BEGIN
   SELECT
@@ -3519,7 +3519,7 @@ DELIMITER $$
 -- Create procedure `sp_getDistritos`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getDistritos (IN p_id_provincia varchar(4))
 BEGIN
   SELECT
@@ -3595,7 +3595,7 @@ DELIMITER $$
 -- Create procedure `sp_updateEmpresa`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_updateEmpresa (IN p_id int,
 IN p_nombre_largo varchar(255),
 IN p_nombre_corto varchar(100),
@@ -3639,7 +3639,7 @@ $$
 -- Create procedure `sp_leer_venta_por_id`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_leer_venta_por_id (IN `p_id_venta` int)
 BEGIN
   -- Primero, obtener los datos principales de la venta, del cliente y de la empresa
@@ -3694,7 +3694,7 @@ $$
 -- Create procedure `sp_getOneEmpresa`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getOneEmpresa (IN p_id int)
 BEGIN
   SELECT
@@ -3708,7 +3708,7 @@ $$
 -- Create procedure `sp_getAllEmpresas`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_getAllEmpresas ()
 BEGIN
   SELECT
@@ -3725,7 +3725,7 @@ $$
 -- Create procedure `sp_deleteEmpresa`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_deleteEmpresa (IN p_id int)
 BEGIN
   DELETE
@@ -3738,7 +3738,7 @@ $$
 -- Create procedure `sp_createEmpresa`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_createEmpresa (IN p_nombre_largo varchar(255),
 IN p_nombre_corto varchar(100),
 IN p_ruc varchar(11),
@@ -3795,7 +3795,7 @@ DELIMITER $$
 -- Create procedure `sp_update_unidad_medida`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_update_unidad_medida (IN p_id int,
 IN p_codigo varchar(10),
 IN p_descripcion varchar(255),
@@ -3813,7 +3813,7 @@ $$
 -- Create procedure `sp_read_unidades_medida`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_read_unidades_medida (IN p_filter varchar(255),
 IN p_limit int,
 IN p_offset int)
@@ -3835,7 +3835,7 @@ $$
 -- Create procedure `sp_get_unidad_medida_by_id`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_get_unidad_medida_by_id (IN p_id int)
 BEGIN
   SELECT
@@ -3852,7 +3852,7 @@ $$
 -- Create procedure `sp_delete_unidad_medida`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_delete_unidad_medida (IN p_id int)
 BEGIN
   UPDATE `unidades_medida`
@@ -3865,7 +3865,7 @@ $$
 -- Create procedure `sp_create_unidad_medida`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_create_unidad_medida (IN p_codigo varchar(10),
 IN p_descripcion varchar(255))
 BEGIN
@@ -3880,7 +3880,7 @@ $$
 -- Create procedure `sp_count_unidades_medida`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_count_unidades_medida (IN p_filter varchar(255))
 BEGIN
   SELECT
@@ -3950,7 +3950,7 @@ DELIMITER $$
 -- Create procedure `sp_update_movimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_update_movimiento (IN p_id_movimiento bigint,
 IN p_anio char(4),
 IN p_periodo char(2),
@@ -4012,7 +4012,7 @@ $$
 -- Create procedure `sp_get_movimiento_by_id`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_get_movimiento_by_id (IN p_id bigint)
 BEGIN
   -- Obtener cabecera
@@ -4045,7 +4045,7 @@ $$
 -- Create procedure `sp_create_movimiento`
 --
 CREATE
-DEFINER = 'miguel'@'%'
+
 PROCEDURE sp_create_movimiento (IN p_anio char(4),
 IN p_periodo char(2),
 IN p_codigo_movimiento int,
@@ -4133,7 +4133,7 @@ DELIMITER $$
 -- Create procedure `sp_leer_impuestos`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_leer_impuestos (IN p_codigo char(3),
 IN p_estado boolean,
 IN p_offset int,
@@ -4160,7 +4160,7 @@ $$
 -- Create procedure `sp_leer_impuesto_por_id`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_leer_impuesto_por_id (IN p_id int)
 BEGIN
   SELECT
@@ -4179,7 +4179,7 @@ $$
 -- Create procedure `sp_leer_codigos_impuesto`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_leer_codigos_impuesto ()
 BEGIN
   SELECT DISTINCT
@@ -4193,7 +4193,7 @@ $$
 -- Create procedure `sp_eliminar_impuesto`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_eliminar_impuesto (IN p_id int)
 BEGIN
   DELETE
@@ -4206,7 +4206,7 @@ $$
 -- Create procedure `sp_crear_impuesto`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_crear_impuesto (IN p_codigo char(3),
 IN p_fecha_inicial date,
 IN p_fecha_final date,
@@ -4222,7 +4222,7 @@ $$
 -- Create procedure `sp_contar_impuestos`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_contar_impuestos (IN p_codigo char(3),
 IN p_estado boolean)
 BEGIN
@@ -4241,7 +4241,7 @@ $$
 -- Create procedure `sp_calcular_y_actualizar_impuestos_venta`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_calcular_y_actualizar_impuestos_venta (IN p_id_venta int)
 BEGIN
   -- Declaración de variables para almacenar los valores calculados
@@ -4300,7 +4300,7 @@ $$
 -- Create procedure `sp_update_venta`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_update_venta (IN p_id_venta int,
 IN p_fecha_emision datetime)
 BEGIN
@@ -4328,7 +4328,7 @@ $$
 -- Create procedure `sp_crear_venta_con_impuestos`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_crear_venta_con_impuestos (IN p_id_pedido int,
 IN p_id_cliente int,
 IN p_id_usuario_cajero int,
@@ -4397,7 +4397,7 @@ $$
 -- Create procedure `sp_actualizar_impuesto`
 --
 CREATE
-DEFINER = 'miguel'@'localhost'
+
 PROCEDURE sp_actualizar_impuesto (IN p_id int,
 IN p_codigo char(3),
 IN p_fecha_inicial date,

--- a/migrations/sc_005_add_movimiento_salida_por_venta.sql
+++ b/migrations/sc_005_add_movimiento_salida_por_venta.sql
@@ -1,0 +1,103 @@
+-- Drop procedures if they exist
+DROP PROCEDURE IF EXISTS sp_verificar_movimiento_por_pedido;
+DROP PROCEDURE IF EXISTS sp_crear_movimiento_salida_por_venta;
+
+DELIMITER $$
+
+--
+-- Procedimiento para verificar si ya existe un movimiento de salida para un pedido
+--
+CREATE PROCEDURE sp_verificar_movimiento_por_pedido(IN p_id_pedido INT)
+BEGIN
+    SELECT COUNT(id) AS movimiento_existente
+    FROM movimientos
+    WHERE id_pedido = p_id_pedido AND tipo_movimiento = 'S';
+END$$
+
+--
+-- Procedimiento para crear un movimiento de salida a partir de una venta (pedido)
+--
+CREATE PROCEDURE sp_crear_movimiento_salida_por_venta(IN p_id_pedido INT)
+BEGIN
+    DECLARE v_anio CHAR(4);
+    DECLARE v_periodo CHAR(2);
+    DECLARE v_fecha_movimiento DATE;
+    DECLARE v_id_cliente INT;
+    DECLARE v_id_almacen INT;
+    DECLARE v_id_movimiento BIGINT;
+
+    DECLARE v_done INT DEFAULT FALSE;
+    DECLARE v_item INT;
+    DECLARE v_id_producto INT;
+    DECLARE v_cantidad DECIMAL(14, 5);
+    DECLARE v_descripcion_producto TEXT;
+
+    -- Cursor para iterar sobre los detalles del pedido
+    DECLARE cur_detalle CURSOR FOR
+        SELECT dp.id, dp.id_producto, dp.cantidad, p.nombre
+        FROM detalle_pedidos dp
+        JOIN productos p ON dp.id_producto = p.id
+        WHERE dp.id_pedido = p_id_pedido;
+
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET v_done = TRUE;
+
+    -- Obtener datos de la cabecera del pedido
+    SELECT
+        YEAR(fecha_creacion),
+        LPAD(MONTH(fecha_creacion), 2, '0'),
+        DATE(fecha_creacion),
+        id_cliente
+    INTO v_anio, v_periodo, v_fecha_movimiento, v_id_cliente
+    FROM pedidos
+    WHERE id = p_id_pedido;
+
+    -- Obtener el almacén predeterminado
+    SELECT id INTO v_id_almacen FROM almacenes WHERE predeterminado = 1 LIMIT 1;
+
+    START TRANSACTION;
+
+        -- Insertar la cabecera del movimiento
+        INSERT INTO movimientos (
+            anio, periodo, tipo_movimiento, codigo_movimiento, fecha_movimiento,
+            id_tipo_documento_venta, serie_documento, numero_documento, tipo_entidad,
+            id_cliente, id_proveedor, estado, fecha_creacion,
+            id_almacen, id_pedido
+        ) VALUES (
+            v_anio, v_periodo, 'S', 4, v_fecha_movimiento,
+            6, '0000', DATE_FORMAT(v_fecha_movimiento, '%Y%m%d'), 'C',
+            v_id_cliente, NULL, 'Activado', NOW(),
+            v_id_almacen, p_id_pedido
+        );
+
+        SET v_id_movimiento = LAST_INSERT_ID();
+
+        -- Abrir el cursor y recorrer los detalles del pedido
+        OPEN cur_detalle;
+
+        read_loop: LOOP
+            FETCH cur_detalle INTO v_item, v_id_producto, v_cantidad, v_descripcion_producto;
+            IF v_done THEN
+                LEAVE read_loop;
+            END IF;
+
+            -- Insertar el detalle del movimiento
+            INSERT INTO movimientos_detalle (
+                id_movimiento, item, id_producto, cantidad, id_producto_padre,
+                cantidad_padre, descripcion, codigo_unidad_medida, costo_unitario,
+                costo_neto, costo_promedio
+            ) VALUES (
+                v_id_movimiento, v_item, v_id_producto, v_cantidad, NULL,
+                NULL, v_descripcion_producto, 'NIU', 0, 0, NULL
+            );
+
+        END LOOP;
+
+        CLOSE cur_detalle;
+
+    COMMIT;
+
+    SELECT v_id_movimiento AS id_movimiento;
+
+END$$
+
+DELIMITER ;


### PR DESCRIPTION
Implementa la creación automática de un movimiento de tipo 'Salida' después de que se genera una venta a partir de un pedido.

- Se añaden los procedimientos almacenados `sp_verificar_movimiento_por_pedido` y `sp_crear_movimiento_salida_por_venta`.
- Se actualiza el modelo `Movimiento.php` con métodos para llamar a los nuevos procedimientos.
- Se modifica el endpoint `procesar_venta.php` para:
  1. Validar que no exista un movimiento de salida previo para el pedido.
  2. Envolver la creación de la venta y del movimiento en una transacción de base de datos para garantizar la atomicidad.
  3. Crear el movimiento de salida después de que la venta se haya generado con éxito.
- Se restaura la base de datos en el entorno de desarrollo y se aplican las nuevas migraciones.